### PR TITLE
Clean up LinearLayout building

### DIFF
--- a/backend-embedded-graphics/src/themes/default/check_box/mod.rs
+++ b/backend-embedded-graphics/src/themes/default/check_box/mod.rs
@@ -103,12 +103,8 @@ where
     CheckBoxStyle<C>: Default,
 {
     Toggle::new(
-        Row::new(Cell::new(
-            CheckBox::<CheckBoxStyle<C>>::new().on_state_changed(S::apply_check_box),
-        ))
-        .spacing(1)
-        .add(Cell::new(
-            Label::new(label).on_state_changed(S::apply_label),
-        )),
+        Row::new(CheckBox::<CheckBoxStyle<C>>::new().on_state_changed(S::apply_check_box))
+            .spacing(1)
+            .add(Label::new(label).on_state_changed(S::apply_label)),
     )
 }

--- a/backend-embedded-graphics/src/themes/default/check_box/mod.rs
+++ b/backend-embedded-graphics/src/themes/default/check_box/mod.rs
@@ -89,8 +89,7 @@ pub type StyledCheckBox<'a, 'b, 'c, C> = Toggle<
             Cell<Label<&'static str, LabelStyle<MonoTextStyle<'a, 'b, 'c, C>>>>,
             Chain<Cell<CheckBox<CheckBoxStyle<C>>>>,
         >,
-        Row,
-        WithSpacing,
+        Row<WithSpacing>,
     >,
     (),
     true,
@@ -103,8 +102,9 @@ where
     CheckBoxStyle<C>: Default,
 {
     Toggle::new(
-        Row::new(CheckBox::<CheckBoxStyle<C>>::new().on_state_changed(S::apply_check_box))
+        Row::new()
             .spacing(1)
+            .add(CheckBox::<CheckBoxStyle<C>>::new().on_state_changed(S::apply_check_box))
             .add(Label::new(label).on_state_changed(S::apply_label)),
     )
 }

--- a/backend-embedded-graphics/src/themes/default/radio_button/mod.rs
+++ b/backend-embedded-graphics/src/themes/default/radio_button/mod.rs
@@ -92,8 +92,7 @@ pub type StyledRadioButton<'a, 'b, 'c, C> = Toggle<
             Cell<Label<&'static str, LabelStyle<MonoTextStyle<'a, 'b, 'c, C>>>>,
             Chain<Cell<RadioButton<RadioButtonStyle<C>>>>,
         >,
-        Row,
-        WithSpacing,
+        Row<WithSpacing>,
     >,
     (),
     false,
@@ -106,8 +105,9 @@ where
     RadioButtonStyle<C>: Default,
 {
     Toggle::new(
-        Row::new(RadioButton::<RadioButtonStyle<C>>::new().on_state_changed(S::apply_radio_button))
+        Row::new()
             .spacing(1)
+            .add(RadioButton::<RadioButtonStyle<C>>::new().on_state_changed(S::apply_radio_button))
             .add(Label::new(label).on_state_changed(S::apply_label)),
     )
     .disallow_manual_uncheck()

--- a/backend-embedded-graphics/src/themes/default/radio_button/mod.rs
+++ b/backend-embedded-graphics/src/themes/default/radio_button/mod.rs
@@ -106,13 +106,9 @@ where
     RadioButtonStyle<C>: Default,
 {
     Toggle::new(
-        Row::new(Cell::new(
-            RadioButton::<RadioButtonStyle<C>>::new().on_state_changed(S::apply_radio_button),
-        ))
-        .spacing(1)
-        .add(Cell::new(
-            Label::new(label).on_state_changed(S::apply_label),
-        )),
+        Row::new(RadioButton::<RadioButtonStyle<C>>::new().on_state_changed(S::apply_radio_button))
+            .spacing(1)
+            .add(Label::new(label).on_state_changed(S::apply_label)),
     )
     .disallow_manual_uncheck()
 }

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -207,144 +207,150 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(
-            Spacing::new(
-                FillParent::horizontal(
-                    Label::new(String::<U11>::from("0"))
-                        .font(&FONT_10X20)
-                        .bind(&calculator)
-                        .on_data_changed(|label, calc| {
-                            label.text.clear();
-                            write!(label.text, "{}", calc.current).unwrap();
-                        }),
+        Column::new()
+            .spacing(1)
+            .add(
+                Spacing::new(
+                    FillParent::horizontal(
+                        Label::new(String::<U11>::from("0"))
+                            .font(&FONT_10X20)
+                            .bind(&calculator)
+                            .on_data_changed(|label, calc| {
+                                label.text.clear();
+                                write!(label.text, "{}", calc.current).unwrap();
+                            }),
+                    )
+                    .align_horizontal(Right),
                 )
-                .align_horizontal(Right),
+                .all(4),
             )
-            .all(4),
-        )
-        .spacing(1)
-        .add(
-            Row::new(
-                DefaultTheme::primary_button("CE")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.clear()),
-            )
-            .weight(2)
-            .spacing(1)
             .add(
-                DefaultTheme::secondary_button("<")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.delete_digit()),
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::primary_button("CE")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.clear()),
+                    )
+                    .weight(2)
+                    .add(
+                        DefaultTheme::secondary_button("<")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.delete_digit()),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::primary_button("/")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.set_op(Op::Divide)),
+                    )
+                    .weight(1),
             )
             .weight(1)
             .add(
-                DefaultTheme::primary_button("/")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.set_op(Op::Divide)),
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::secondary_button("7")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(7)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("8")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(8)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("9")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(9)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::primary_button("x")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.set_op(Op::Multiply)),
+                    )
+                    .weight(1),
+            )
+            .weight(1)
+            .add(
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::secondary_button("4")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(4)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("5")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(5)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("6")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(6)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::primary_button("-")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.set_op(Op::Subtract)),
+                    )
+                    .weight(1),
+            )
+            .weight(1)
+            .add(
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::secondary_button("1")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(1)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("2")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(2)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("3")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(3)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::primary_button("+")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.set_op(Op::Add)),
+                    )
+                    .weight(1),
+            )
+            .weight(1)
+            .add(
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::secondary_button("0")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(0)),
+                    )
+                    .weight(3)
+                    .add(
+                        DefaultTheme::primary_button("=")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.update()),
+                    )
+                    .weight(1),
             )
             .weight(1),
-        )
-        .weight(1)
-        .add(
-            Row::new(
-                DefaultTheme::secondary_button("7")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(7)),
-            )
-            .weight(1)
-            .spacing(1)
-            .add(
-                DefaultTheme::secondary_button("8")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(8)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::secondary_button("9")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(9)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::primary_button("x")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.set_op(Op::Multiply)),
-            )
-            .weight(1),
-        )
-        .weight(1)
-        .add(
-            Row::new(
-                DefaultTheme::secondary_button("4")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(4)),
-            )
-            .weight(1)
-            .spacing(1)
-            .add(
-                DefaultTheme::secondary_button("5")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(5)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::secondary_button("6")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(6)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::primary_button("-")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.set_op(Op::Subtract)),
-            )
-            .weight(1),
-        )
-        .weight(1)
-        .add(
-            Row::new(
-                DefaultTheme::secondary_button("1")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(1)),
-            )
-            .weight(1)
-            .spacing(1)
-            .add(
-                DefaultTheme::secondary_button("2")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(2)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::secondary_button("3")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(3)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::primary_button("+")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.set_op(Op::Add)),
-            )
-            .weight(1),
-        )
-        .weight(1)
-        .add(
-            Row::new(
-                DefaultTheme::secondary_button("0")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(0)),
-            )
-            .weight(3)
-            .spacing(1)
-            .add(
-                DefaultTheme::primary_button("=")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.update()),
-            )
-            .weight(1),
-        )
-        .weight(1),
     );
 
     println!("Size of struct: {}", std::mem::size_of_val(&gui.root));

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -19,7 +19,7 @@ use embedded_gui::{
     input::event::{InputEvent, PointerEvent},
     widgets::{
         label::Label,
-        layouts::linear::{column::Column, row::Row, Cell},
+        layouts::linear::{column::Column, row::Row},
         primitives::{
             fill::{FillParent, Right},
             spacing::Spacing,
@@ -207,8 +207,8 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Spacing::new(
-            Column::new(Cell::new(
+        Column::new(
+            Spacing::new(
                 FillParent::horizontal(
                     Label::new(String::<U11>::from("0"))
                         .font(&FONT_10X20)
@@ -219,176 +219,132 @@ fn main() {
                         }),
                 )
                 .align_horizontal(Right),
-            ))
+            )
+            .all(4),
+        )
+        .spacing(1)
+        .add(
+            Row::new(
+                DefaultTheme::primary_button("CE")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.clear()),
+            )
+            .weight(2)
             .spacing(1)
             .add(
-                Cell::new(
-                    Row::new(
-                        Cell::new(
-                            DefaultTheme::primary_button("CE")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.clear()),
-                        )
-                        .weight(2),
-                    )
-                    .spacing(1)
-                    .add(
-                        Cell::new(
-                            DefaultTheme::secondary_button("<")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.delete_digit()),
-                        )
-                        .weight(1),
-                    )
-                    .add(
-                        Cell::new(
-                            DefaultTheme::primary_button("/")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.set_op(Op::Divide)),
-                        )
-                        .weight(1),
-                    ),
-                )
-                .weight(1),
+                DefaultTheme::secondary_button("<")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.delete_digit()),
             )
+            .weight(1)
             .add(
-                Cell::new(
-                    Row::new(
-                        Cell::new(
-                            DefaultTheme::secondary_button("7")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(7)),
-                        )
-                        .weight(1),
-                    )
-                    .spacing(1)
-                    .add(
-                        Cell::new(
-                            DefaultTheme::secondary_button("8")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(8)),
-                        )
-                        .weight(1),
-                    )
-                    .add(
-                        Cell::new(
-                            DefaultTheme::secondary_button("9")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(9)),
-                        )
-                        .weight(1),
-                    )
-                    .add(
-                        Cell::new(
-                            DefaultTheme::primary_button("x")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.set_op(Op::Multiply)),
-                        )
-                        .weight(1),
-                    ),
-                )
-                .weight(1),
+                DefaultTheme::primary_button("/")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.set_op(Op::Divide)),
             )
-            .add(
-                Cell::new(
-                    Row::new(
-                        Cell::new(
-                            DefaultTheme::secondary_button("4")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(4)),
-                        )
-                        .weight(1),
-                    )
-                    .spacing(1)
-                    .add(
-                        Cell::new(
-                            DefaultTheme::secondary_button("5")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(5)),
-                        )
-                        .weight(1),
-                    )
-                    .add(
-                        Cell::new(
-                            DefaultTheme::secondary_button("6")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(6)),
-                        )
-                        .weight(1),
-                    )
-                    .add(
-                        Cell::new(
-                            DefaultTheme::primary_button("-")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.set_op(Op::Subtract)),
-                        )
-                        .weight(1),
-                    ),
-                )
-                .weight(1),
-            )
-            .add(
-                Cell::new(
-                    Row::new(
-                        Cell::new(
-                            DefaultTheme::secondary_button("1")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(1)),
-                        )
-                        .weight(1),
-                    )
-                    .spacing(1)
-                    .add(
-                        Cell::new(
-                            DefaultTheme::secondary_button("2")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(2)),
-                        )
-                        .weight(1),
-                    )
-                    .add(
-                        Cell::new(
-                            DefaultTheme::secondary_button("3")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(3)),
-                        )
-                        .weight(1),
-                    )
-                    .add(
-                        Cell::new(
-                            DefaultTheme::primary_button("+")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.set_op(Op::Add)),
-                        )
-                        .weight(1),
-                    ),
-                )
-                .weight(1),
-            )
-            .add(
-                Cell::new(
-                    Row::new(
-                        Cell::new(
-                            DefaultTheme::secondary_button("0")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.add_digit(0)),
-                        )
-                        .weight(3),
-                    )
-                    .spacing(1)
-                    .add(
-                        Cell::new(
-                            DefaultTheme::primary_button("=")
-                                .bind(&calculator)
-                                .on_clicked(|calculator| calculator.update()),
-                        )
-                        .weight(1),
-                    ),
-                )
-                .weight(1),
-            ),
+            .weight(1),
         )
-        .all(2),
+        .weight(1)
+        .add(
+            Row::new(
+                DefaultTheme::secondary_button("7")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(7)),
+            )
+            .weight(1)
+            .spacing(1)
+            .add(
+                DefaultTheme::secondary_button("8")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(8)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::secondary_button("9")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(9)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("x")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.set_op(Op::Multiply)),
+            )
+            .weight(1),
+        )
+        .weight(1)
+        .add(
+            Row::new(
+                DefaultTheme::secondary_button("4")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(4)),
+            )
+            .weight(1)
+            .spacing(1)
+            .add(
+                DefaultTheme::secondary_button("5")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(5)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::secondary_button("6")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(6)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("-")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.set_op(Op::Subtract)),
+            )
+            .weight(1),
+        )
+        .weight(1)
+        .add(
+            Row::new(
+                DefaultTheme::secondary_button("1")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(1)),
+            )
+            .weight(1)
+            .spacing(1)
+            .add(
+                DefaultTheme::secondary_button("2")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(2)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::secondary_button("3")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(3)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("+")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.set_op(Op::Add)),
+            )
+            .weight(1),
+        )
+        .weight(1)
+        .add(
+            Row::new(
+                DefaultTheme::secondary_button("0")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(0)),
+            )
+            .weight(3)
+            .spacing(1)
+            .add(
+                DefaultTheme::primary_button("=")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.update()),
+            )
+            .weight(1),
+        )
+        .weight(1),
     );
 
     println!("Size of struct: {}", std::mem::size_of_val(&gui.root));

--- a/examples/calculator_rgb.rs
+++ b/examples/calculator_rgb.rs
@@ -20,7 +20,7 @@ use embedded_gui::{
     input::event::{InputEvent, PointerEvent},
     widgets::{
         label::Label,
-        layouts::linear::{column::Column, row::Row, Cell},
+        layouts::linear::{column::Column, row::Row},
         primitives::{
             background::Background,
             fill::{FillParent, Right},
@@ -227,7 +227,7 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(Cell::new(
+        Column::new(
             Background::new(
                 Spacing::new(
                     FillParent::horizontal(
@@ -245,177 +245,133 @@ fn main() {
                 .all(4),
             )
             .background_color(Rgb888::CSS_DARK_GRAY),
-        ))
+        )
         .spacing(1)
         .add(
-            Cell::new(
-                Row::new(
-                    Cell::new(
-                        DefaultTheme::primary_button("CE")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.clear()),
-                    )
-                    .weight(2),
-                )
-                .spacing(1)
-                .add(
-                    Cell::new(
-                        DefaultTheme::secondary_button("<")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.delete_digit()),
-                    )
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
-                        DefaultTheme::primary_button("/")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.set_op(Op::Divide)),
-                    )
-                    .weight(1),
-                ),
+            Row::new(
+                DefaultTheme::primary_button("CE")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.clear()),
+            )
+            .weight(2)
+            .spacing(1)
+            .add(
+                DefaultTheme::secondary_button("<")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.delete_digit()),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("/")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.set_op(Op::Divide)),
             )
             .weight(1),
         )
+        .weight(1)
         .add(
-            Cell::new(
-                Row::new(
-                    Cell::new(
-                        DefaultTheme::secondary_button("7")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(7)),
-                    )
-                    .weight(1),
-                )
-                .spacing(1)
-                .add(
-                    Cell::new(
-                        DefaultTheme::secondary_button("8")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(8)),
-                    )
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
-                        DefaultTheme::secondary_button("9")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(9)),
-                    )
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
-                        DefaultTheme::primary_button("x")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.set_op(Op::Multiply)),
-                    )
-                    .weight(1),
-                ),
+            Row::new(
+                DefaultTheme::secondary_button("7")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(7)),
+            )
+            .weight(1)
+            .spacing(1)
+            .add(
+                DefaultTheme::secondary_button("8")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(8)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::secondary_button("9")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(9)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("x")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.set_op(Op::Multiply)),
             )
             .weight(1),
         )
+        .weight(1)
         .add(
-            Cell::new(
-                Row::new(
-                    Cell::new(
-                        DefaultTheme::secondary_button("4")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(4)),
-                    )
-                    .weight(1),
-                )
-                .spacing(1)
-                .add(
-                    Cell::new(
-                        DefaultTheme::secondary_button("5")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(5)),
-                    )
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
-                        DefaultTheme::secondary_button("6")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(6)),
-                    )
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
-                        DefaultTheme::primary_button("-")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.set_op(Op::Subtract)),
-                    )
-                    .weight(1),
-                ),
+            Row::new(
+                DefaultTheme::secondary_button("4")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(4)),
+            )
+            .weight(1)
+            .spacing(1)
+            .add(
+                DefaultTheme::secondary_button("5")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(5)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::secondary_button("6")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(6)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("-")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.set_op(Op::Subtract)),
             )
             .weight(1),
         )
+        .weight(1)
         .add(
-            Cell::new(
-                Row::new(
-                    Cell::new(
-                        DefaultTheme::secondary_button("1")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(1)),
-                    )
-                    .weight(1),
-                )
-                .spacing(1)
-                .add(
-                    Cell::new(
-                        DefaultTheme::secondary_button("2")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(2)),
-                    )
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
-                        DefaultTheme::secondary_button("3")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(3)),
-                    )
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
-                        DefaultTheme::primary_button("+")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.set_op(Op::Add)),
-                    )
-                    .weight(1),
-                ),
+            Row::new(
+                DefaultTheme::secondary_button("1")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(1)),
+            )
+            .weight(1)
+            .spacing(1)
+            .add(
+                DefaultTheme::secondary_button("2")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(2)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::secondary_button("3")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(3)),
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("+")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.set_op(Op::Add)),
             )
             .weight(1),
         )
+        .weight(1)
         .add(
-            Cell::new(
-                Row::new(
-                    Cell::new(
-                        DefaultTheme::secondary_button("0")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.add_digit(0)),
-                    )
-                    .weight(3),
-                )
-                .spacing(1)
-                .add(
-                    Cell::new(
-                        DefaultTheme::primary_button("=")
-                            .bind(&calculator)
-                            .on_clicked(|calculator| calculator.update())
-                            .on_data_changed(|button, calculator| {
-                                button.set_active(calculator.op_valid());
-                            }),
-                    )
-                    .weight(1),
-                ),
+            Row::new(
+                DefaultTheme::secondary_button("0")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.add_digit(0)),
+            )
+            .weight(3)
+            .spacing(1)
+            .add(
+                DefaultTheme::primary_button("=")
+                    .bind(&calculator)
+                    .on_clicked(|calculator| calculator.update())
+                    .on_data_changed(|button, calculator| {
+                        button.set_active(calculator.op_valid());
+                    }),
             )
             .weight(1),
-        ),
+        )
+        .weight(1),
     );
 
     println!("Size of struct: {}", std::mem::size_of_val(&gui.root));

--- a/examples/calculator_rgb.rs
+++ b/examples/calculator_rgb.rs
@@ -227,151 +227,157 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(
-            Background::new(
-                Spacing::new(
-                    FillParent::horizontal(
-                        Label::new(String::<U11>::from("0"))
-                            .font(&FONT_10X20)
-                            .text_color(Rgb888::BLACK)
+        Column::new()
+            .spacing(1)
+            .add(
+                Background::new(
+                    Spacing::new(
+                        FillParent::horizontal(
+                            Label::new(String::<U11>::from("0"))
+                                .font(&FONT_10X20)
+                                .text_color(Rgb888::BLACK)
+                                .bind(&calculator)
+                                .on_data_changed(|label, calc| {
+                                    label.text.clear();
+                                    write!(label.text, "{}", calc.current).unwrap();
+                                }),
+                        )
+                        .align_horizontal(Right),
+                    )
+                    .all(4),
+                )
+                .background_color(Rgb888::CSS_DARK_GRAY),
+            )
+            .add(
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::primary_button("CE")
                             .bind(&calculator)
-                            .on_data_changed(|label, calc| {
-                                label.text.clear();
-                                write!(label.text, "{}", calc.current).unwrap();
+                            .on_clicked(|calculator| calculator.clear()),
+                    )
+                    .weight(2)
+                    .add(
+                        DefaultTheme::secondary_button("<")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.delete_digit()),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::primary_button("/")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.set_op(Op::Divide)),
+                    )
+                    .weight(1),
+            )
+            .weight(1)
+            .add(
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::secondary_button("7")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(7)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("8")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(8)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("9")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(9)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::primary_button("x")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.set_op(Op::Multiply)),
+                    )
+                    .weight(1),
+            )
+            .weight(1)
+            .add(
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::secondary_button("4")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(4)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("5")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(5)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("6")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(6)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::primary_button("-")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.set_op(Op::Subtract)),
+                    )
+                    .weight(1),
+            )
+            .weight(1)
+            .add(
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::secondary_button("1")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(1)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("2")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(2)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::secondary_button("3")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(3)),
+                    )
+                    .weight(1)
+                    .add(
+                        DefaultTheme::primary_button("+")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.set_op(Op::Add)),
+                    )
+                    .weight(1),
+            )
+            .weight(1)
+            .add(
+                Row::new()
+                    .spacing(1)
+                    .add(
+                        DefaultTheme::secondary_button("0")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.add_digit(0)),
+                    )
+                    .weight(3)
+                    .add(
+                        DefaultTheme::primary_button("=")
+                            .bind(&calculator)
+                            .on_clicked(|calculator| calculator.update())
+                            .on_data_changed(|button, calculator| {
+                                button.set_active(calculator.op_valid());
                             }),
                     )
-                    .align_horizontal(Right),
-                )
-                .all(4),
-            )
-            .background_color(Rgb888::CSS_DARK_GRAY),
-        )
-        .spacing(1)
-        .add(
-            Row::new(
-                DefaultTheme::primary_button("CE")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.clear()),
-            )
-            .weight(2)
-            .spacing(1)
-            .add(
-                DefaultTheme::secondary_button("<")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.delete_digit()),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::primary_button("/")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.set_op(Op::Divide)),
+                    .weight(1),
             )
             .weight(1),
-        )
-        .weight(1)
-        .add(
-            Row::new(
-                DefaultTheme::secondary_button("7")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(7)),
-            )
-            .weight(1)
-            .spacing(1)
-            .add(
-                DefaultTheme::secondary_button("8")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(8)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::secondary_button("9")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(9)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::primary_button("x")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.set_op(Op::Multiply)),
-            )
-            .weight(1),
-        )
-        .weight(1)
-        .add(
-            Row::new(
-                DefaultTheme::secondary_button("4")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(4)),
-            )
-            .weight(1)
-            .spacing(1)
-            .add(
-                DefaultTheme::secondary_button("5")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(5)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::secondary_button("6")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(6)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::primary_button("-")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.set_op(Op::Subtract)),
-            )
-            .weight(1),
-        )
-        .weight(1)
-        .add(
-            Row::new(
-                DefaultTheme::secondary_button("1")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(1)),
-            )
-            .weight(1)
-            .spacing(1)
-            .add(
-                DefaultTheme::secondary_button("2")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(2)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::secondary_button("3")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(3)),
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::primary_button("+")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.set_op(Op::Add)),
-            )
-            .weight(1),
-        )
-        .weight(1)
-        .add(
-            Row::new(
-                DefaultTheme::secondary_button("0")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.add_digit(0)),
-            )
-            .weight(3)
-            .spacing(1)
-            .add(
-                DefaultTheme::primary_button("=")
-                    .bind(&calculator)
-                    .on_clicked(|calculator| calculator.update())
-                    .on_data_changed(|button, calculator| {
-                        button.set_active(calculator.op_valid());
-                    }),
-            )
-            .weight(1),
-        )
-        .weight(1),
     );
 
     println!("Size of struct: {}", std::mem::size_of_val(&gui.root));

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -23,7 +23,7 @@ use embedded_gui::{
     widgets::{
         button::Button,
         label::Label,
-        layouts::linear::{column::Column, row::Row, Cell},
+        layouts::linear::{column::Column, row::Row},
         primitives::{
             background::Background,
             border::Border,
@@ -143,17 +143,13 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(Cell::new(
-            Row::new(
-                Cell::new(FillParent::horizontal(Label::new("Hello,")).align_horizontal(Center))
-                    .weight(1),
-            )
-            .add(
-                Cell::new(FillParent::horizontal(Label::new("World!")).align_horizontal(Center))
-                    .weight(1),
-            ),
-        ))
-        .add(Cell::new(
+        Column::new(
+            Row::new(FillParent::horizontal(Label::new("Hello,")).align_horizontal(Center))
+                .weight(1)
+                .add(FillParent::horizontal(Label::new("World!")).align_horizontal(Center))
+                .weight(1),
+        )
+        .add(
             Spacing::new(
                 button_with_style(Label::new("Click me").bind(&flag).on_data_changed(
                     |widget, data| {
@@ -167,7 +163,7 @@ fn main() {
                 }),
             )
             .all(4),
-        )),
+        ),
     );
 
     let output_settings = OutputSettingsBuilder::new()

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -143,27 +143,29 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(
-            Row::new(FillParent::horizontal(Label::new("Hello,")).align_horizontal(Center))
-                .weight(1)
-                .add(FillParent::horizontal(Label::new("World!")).align_horizontal(Center))
-                .weight(1),
-        )
-        .add(
-            Spacing::new(
-                button_with_style(Label::new("Click me").bind(&flag).on_data_changed(
-                    |widget, data| {
-                        widget.text = if *data { "on" } else { "off" };
-                    },
-                ))
-                .bind(&flag)
-                .on_clicked(|data| {
-                    *data = !*data;
-                    println!("Clicked!");
-                }),
+        Column::new()
+            .add(
+                Row::new()
+                    .add(FillParent::horizontal(Label::new("Hello,")).align_horizontal(Center))
+                    .weight(1)
+                    .add(FillParent::horizontal(Label::new("World!")).align_horizontal(Center))
+                    .weight(1),
             )
-            .all(4),
-        ),
+            .add(
+                Spacing::new(
+                    button_with_style(Label::new("Click me").bind(&flag).on_data_changed(
+                        |widget, data| {
+                            widget.text = if *data { "on" } else { "off" };
+                        },
+                    ))
+                    .bind(&flag)
+                    .on_clicked(|data| {
+                        *data = !*data;
+                        println!("Clicked!");
+                    }),
+                )
+                .all(4),
+            ),
     );
 
     let output_settings = OutputSettingsBuilder::new()

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write, thread, time::Duration};
 
 use backend_embedded_graphics::{
     themes::{default::DefaultTheme, Theme},
-    widgets::label::{ascii::LabelConstructor, LabelStyling},
+    widgets::label::ascii::LabelConstructor,
     EgCanvas,
 };
 use embedded_graphics::{
@@ -18,7 +18,7 @@ use embedded_gui::{
     input::event::{InputEvent, PointerEvent, ScrollEvent},
     widgets::{
         label::Label,
-        layouts::linear::{column::Column, row::Row, Cell},
+        layouts::linear::{column::Column, row::Row},
         primitives::{fill::FillParent, spacing::Spacing},
     },
     Window,
@@ -93,59 +93,54 @@ fn main() {
     let mut gui = Window::new(
         EgCanvas::new(display),
         Spacing::new(
-            Column::new(Cell::new(
-                Label::new("Checkboxes and radio buttons").text_color(BinaryColor::On),
-            ))
-            .spacing(1)
-            .add(Cell::new(
-                DefaultTheme::check_box("Check me")
-                    .bind(&checkbox)
-                    .on_selected_changed(|checked, data| {
-                        *data = checked;
-                    })
-                    .on_data_changed(|checkbox, data| {
-                        checkbox.set_checked(*data);
-                    }),
-            ))
-            .add(Cell::new(
-                DefaultTheme::check_box("Inactive")
-                    .bind(&checkbox)
-                    .active(false)
-                    .on_data_changed(|checkbox, data| {
-                        checkbox.set_checked(*data);
-                    }),
-            ))
-            .add(Cell::new(
-                DefaultTheme::radio_button("Can't select me")
-                    .bind(&radio)
-                    .on_selected_changed(|_, data| *data = 0)
-                    .on_data_changed(|radio, data| {
-                        radio.set_checked(*data == 0);
-                    })
-                    .active(false),
-            ))
-            .add(Cell::new(
-                DefaultTheme::radio_button("Select me")
-                    .bind(&radio)
-                    .on_selected_changed(|_, data| *data = 0)
-                    .on_data_changed(|radio, data| {
-                        radio.set_checked(*data == 0);
-                    }),
-            ))
-            .add(Cell::new(
-                DefaultTheme::radio_button("... or me!")
-                    .bind(&radio)
-                    .on_selected_changed(|_, data| *data = 1)
-                    .on_data_changed(|radio, data| {
-                        radio.set_checked(*data == 1);
-                    }),
-            ))
-            .add(Cell::new(
-                Spacing::new(Label::new("Numeric sliders")).top(4),
-            ))
-            .add(Cell::new(
-                Row::new(
-                    Cell::new(FillParent::horizontal(
+            Column::new(Label::new("Checkboxes and radio buttons"))
+                .spacing(1)
+                .add(
+                    DefaultTheme::check_box("Check me")
+                        .bind(&checkbox)
+                        .on_selected_changed(|checked, data| {
+                            *data = checked;
+                        }),
+                )
+                .add(
+                    DefaultTheme::check_box("Inactive")
+                        .bind(&checkbox)
+                        .active(false)
+                        .on_data_changed(|checkbox, data| {
+                            checkbox.set_checked(*data);
+                        })
+                        .on_data_changed(|checkbox, data| {
+                            checkbox.set_checked(*data);
+                        }),
+                )
+                .add(
+                    DefaultTheme::radio_button("Can't select me")
+                        .bind(&radio)
+                        .on_selected_changed(|_, data| *data = 0)
+                        .on_data_changed(|radio, data| {
+                            radio.set_checked(*data == 0);
+                        })
+                        .active(false),
+                )
+                .add(
+                    DefaultTheme::radio_button("Select me")
+                        .bind(&radio)
+                        .on_selected_changed(|_, data| *data = 0)
+                        .on_data_changed(|radio, data| {
+                            radio.set_checked(*data == 0);
+                        }),
+                )
+                .add(
+                    DefaultTheme::radio_button("... or me!")
+                        .bind(&radio)
+                        .on_selected_changed(|_, data| *data = 1)
+                        .on_data_changed(|radio, data| {
+                            radio.set_checked(*data == 1);
+                        }),
+                )
+                .add(Spacing::new(Label::new("Numeric sliders")).top(4))
+                .add(
+                    Row::new(FillParent::horizontal(
                         Label::new(String::<U11>::from("0"))
                             .bind(&slider1_data)
                             .on_data_changed(|label, data| {
@@ -153,10 +148,8 @@ fn main() {
                                 write!(label.text, "{}", data).unwrap();
                             }),
                     ))
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
+                    .weight(1)
+                    .add(
                         Spacing::new(
                             DefaultTheme::slider(-100..=100)
                                 .bind(&slider1_data)
@@ -170,11 +163,9 @@ fn main() {
                         .top(1),
                     )
                     .weight(4),
-                ),
-            ))
-            .add(Cell::new(
-                Row::new(
-                    Cell::new(FillParent::horizontal(
+                )
+                .add(
+                    Row::new(FillParent::horizontal(
                         Label::new(String::<U11>::from("0"))
                             .bind(&slider2_data)
                             .on_data_changed(|label, data| {
@@ -182,10 +173,8 @@ fn main() {
                                 write!(label.text, "{}", data).unwrap();
                             }),
                     ))
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
+                    .weight(1)
+                    .add(
                         Spacing::new(
                             DefaultTheme::slider(0..=5)
                                 .bind(&slider2_data)
@@ -199,26 +188,24 @@ fn main() {
                         .top(1),
                     )
                     .weight(4),
-                ),
-            ))
-            .add(Cell::new(
-                Row::new(Cell::new(Label::new("Inactive"))).add(Cell::new(
-                    Spacing::new(
-                        DefaultTheme::slider(0..=5)
-                            .set_active(false)
-                            .bind(&slider2_data)
-                            .on_value_changed(|data, value| {
-                                *data = value;
-                            })
-                            .on_data_changed(|slider, data| {
-                                slider.set_value(*data);
-                            }),
-                    )
-                    .top(1),
-                )),
-            ))
-            .add(
-                Cell::new(
+                )
+                .add(
+                    Row::new(Label::new("Inactive")).add(
+                        Spacing::new(
+                            DefaultTheme::slider(0..=5)
+                                .set_active(false)
+                                .bind(&slider2_data)
+                                .on_value_changed(|data, value| {
+                                    *data = value;
+                                })
+                                .on_data_changed(|slider, data| {
+                                    slider.set_value(*data);
+                                }),
+                        )
+                        .top(1),
+                    ),
+                )
+                .add(
                     DefaultTheme::primary_button("Reset")
                         .bind(&everything)
                         .on_clicked(|data| {
@@ -229,7 +216,6 @@ fn main() {
                         }),
                 )
                 .weight(1),
-            ),
         )
         .all(2),
     );

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -93,8 +93,9 @@ fn main() {
     let mut gui = Window::new(
         EgCanvas::new(display),
         Spacing::new(
-            Column::new(Label::new("Checkboxes and radio buttons"))
+            Column::new()
                 .spacing(1)
+                .add(Label::new("Checkboxes and radio buttons"))
                 .add(
                     DefaultTheme::check_box("Check me")
                         .bind(&checkbox)
@@ -140,57 +141,59 @@ fn main() {
                 )
                 .add(Spacing::new(Label::new("Numeric sliders")).top(4))
                 .add(
-                    Row::new(FillParent::horizontal(
-                        Label::new(String::<U11>::from("0"))
-                            .bind(&slider1_data)
-                            .on_data_changed(|label, data| {
-                                label.text.clear();
-                                write!(label.text, "{}", data).unwrap();
-                            }),
-                    ))
-                    .weight(1)
-                    .add(
-                        Spacing::new(
-                            DefaultTheme::slider(-100..=100)
+                    Row::new()
+                        .add(FillParent::horizontal(
+                            Label::new(String::<U11>::from("0"))
                                 .bind(&slider1_data)
-                                .on_value_changed(|data, value| {
-                                    *data = value;
-                                })
-                                .on_data_changed(|slider, data| {
-                                    slider.set_value(*data);
+                                .on_data_changed(|label, data| {
+                                    label.text.clear();
+                                    write!(label.text, "{}", data).unwrap();
                                 }),
+                        ))
+                        .weight(1)
+                        .add(
+                            Spacing::new(
+                                DefaultTheme::slider(-100..=100)
+                                    .bind(&slider1_data)
+                                    .on_value_changed(|data, value| {
+                                        *data = value;
+                                    })
+                                    .on_data_changed(|slider, data| {
+                                        slider.set_value(*data);
+                                    }),
+                            )
+                            .top(1),
                         )
-                        .top(1),
-                    )
-                    .weight(4),
+                        .weight(4),
                 )
                 .add(
-                    Row::new(FillParent::horizontal(
-                        Label::new(String::<U11>::from("0"))
-                            .bind(&slider2_data)
-                            .on_data_changed(|label, data| {
-                                label.text.clear();
-                                write!(label.text, "{}", data).unwrap();
-                            }),
-                    ))
-                    .weight(1)
-                    .add(
-                        Spacing::new(
-                            DefaultTheme::slider(0..=5)
+                    Row::new()
+                        .add(FillParent::horizontal(
+                            Label::new(String::<U11>::from("0"))
                                 .bind(&slider2_data)
-                                .on_value_changed(|data, value| {
-                                    *data = value;
-                                })
-                                .on_data_changed(|slider, data| {
-                                    slider.set_value(*data);
+                                .on_data_changed(|label, data| {
+                                    label.text.clear();
+                                    write!(label.text, "{}", data).unwrap();
                                 }),
+                        ))
+                        .weight(1)
+                        .add(
+                            Spacing::new(
+                                DefaultTheme::slider(0..=5)
+                                    .bind(&slider2_data)
+                                    .on_value_changed(|data, value| {
+                                        *data = value;
+                                    })
+                                    .on_data_changed(|slider, data| {
+                                        slider.set_value(*data);
+                                    }),
+                            )
+                            .top(1),
                         )
-                        .top(1),
-                    )
-                    .weight(4),
+                        .weight(4),
                 )
                 .add(
-                    Row::new(Label::new("Inactive")).add(
+                    Row::new().add(Label::new("Inactive")).add(
                         Spacing::new(
                             DefaultTheme::slider(0..=5)
                                 .set_active(false)

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -94,8 +94,9 @@ fn main() {
     let mut gui = Window::new(
         EgCanvas::new(display),
         Spacing::new(
-            Column::new(Label::new("Checkboxes and radio buttons").text_color(Rgb888::BLACK))
+            Column::new()
                 .spacing(1)
+                .add(Label::new("Checkboxes and radio buttons").text_color(Rgb888::BLACK))
                 .add(
                     DefaultTheme::check_box("Check me")
                         .bind(&checkbox)
@@ -141,57 +142,59 @@ fn main() {
                 )
                 .add(Spacing::new(Label::new("Numeric sliders")).top(4))
                 .add(
-                    Row::new(FillParent::horizontal(
-                        Label::new(String::<U11>::from("0"))
-                            .bind(&slider1_data)
-                            .on_data_changed(|label, data| {
-                                label.text.clear();
-                                write!(label.text, "{}", data).unwrap();
-                            }),
-                    ))
-                    .weight(1)
-                    .add(
-                        Spacing::new(
-                            DefaultTheme::slider(-100..=100)
+                    Row::new()
+                        .add(FillParent::horizontal(
+                            Label::new(String::<U11>::from("0"))
                                 .bind(&slider1_data)
-                                .on_value_changed(|data, value| {
-                                    *data = value;
-                                })
-                                .on_data_changed(|slider, data| {
-                                    slider.set_value(*data);
+                                .on_data_changed(|label, data| {
+                                    label.text.clear();
+                                    write!(label.text, "{}", data).unwrap();
                                 }),
+                        ))
+                        .weight(1)
+                        .add(
+                            Spacing::new(
+                                DefaultTheme::slider(-100..=100)
+                                    .bind(&slider1_data)
+                                    .on_value_changed(|data, value| {
+                                        *data = value;
+                                    })
+                                    .on_data_changed(|slider, data| {
+                                        slider.set_value(*data);
+                                    }),
+                            )
+                            .top(1),
                         )
-                        .top(1),
-                    )
-                    .weight(4),
+                        .weight(4),
                 )
                 .add(
-                    Row::new(FillParent::horizontal(
-                        Label::new(String::<U11>::from("0"))
-                            .bind(&slider2_data)
-                            .on_data_changed(|label, data| {
-                                label.text.clear();
-                                write!(label.text, "{}", data).unwrap();
-                            }),
-                    ))
-                    .weight(1)
-                    .add(
-                        Spacing::new(
-                            DefaultTheme::slider(0..=5)
+                    Row::new()
+                        .add(FillParent::horizontal(
+                            Label::new(String::<U11>::from("0"))
                                 .bind(&slider2_data)
-                                .on_value_changed(|data, value| {
-                                    *data = value;
-                                })
-                                .on_data_changed(|slider, data| {
-                                    slider.set_value(*data);
+                                .on_data_changed(|label, data| {
+                                    label.text.clear();
+                                    write!(label.text, "{}", data).unwrap();
                                 }),
+                        ))
+                        .weight(1)
+                        .add(
+                            Spacing::new(
+                                DefaultTheme::slider(0..=5)
+                                    .bind(&slider2_data)
+                                    .on_value_changed(|data, value| {
+                                        *data = value;
+                                    })
+                                    .on_data_changed(|slider, data| {
+                                        slider.set_value(*data);
+                                    }),
+                            )
+                            .top(1),
                         )
-                        .top(1),
-                    )
-                    .weight(4),
+                        .weight(4),
                 )
                 .add(
-                    Row::new(Label::new("Inactive")).add(
+                    Row::new().add(Label::new("Inactive")).add(
                         Spacing::new(
                             DefaultTheme::slider(0..=5)
                                 .set_active(false)

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -19,7 +19,7 @@ use embedded_gui::{
     input::event::{InputEvent, PointerEvent, ScrollEvent},
     widgets::{
         label::Label,
-        layouts::linear::{column::Column, row::Row, Cell},
+        layouts::linear::{column::Column, row::Row},
         primitives::{fill::FillParent, spacing::Spacing},
     },
     Window,
@@ -94,59 +94,54 @@ fn main() {
     let mut gui = Window::new(
         EgCanvas::new(display),
         Spacing::new(
-            Column::new(Cell::new(
-                Label::new("Checkboxes and radio buttons").text_color(Rgb888::BLACK),
-            ))
-            .spacing(1)
-            .add(Cell::new(
-                DefaultTheme::check_box("Check me")
-                    .bind(&checkbox)
-                    .on_selected_changed(|checked, data| {
-                        *data = checked;
-                    }),
-            ))
-            .add(Cell::new(
-                DefaultTheme::check_box("Inactive")
-                    .bind(&checkbox)
-                    .active(false)
-                    .on_data_changed(|checkbox, data| {
-                        checkbox.set_checked(*data);
-                    })
-                    .on_data_changed(|checkbox, data| {
-                        checkbox.set_checked(*data);
-                    }),
-            ))
-            .add(Cell::new(
-                DefaultTheme::radio_button("Can't select me")
-                    .bind(&radio)
-                    .on_selected_changed(|_, data| *data = 0)
-                    .on_data_changed(|radio, data| {
-                        radio.set_checked(*data == 0);
-                    })
-                    .active(false),
-            ))
-            .add(Cell::new(
-                DefaultTheme::radio_button("Select me")
-                    .bind(&radio)
-                    .on_selected_changed(|_, data| *data = 0)
-                    .on_data_changed(|radio, data| {
-                        radio.set_checked(*data == 0);
-                    }),
-            ))
-            .add(Cell::new(
-                DefaultTheme::radio_button("... or me!")
-                    .bind(&radio)
-                    .on_selected_changed(|_, data| *data = 1)
-                    .on_data_changed(|radio, data| {
-                        radio.set_checked(*data == 1);
-                    }),
-            ))
-            .add(Cell::new(
-                Spacing::new(Label::new("Numeric sliders")).top(4),
-            ))
-            .add(Cell::new(
-                Row::new(
-                    Cell::new(FillParent::horizontal(
+            Column::new(Label::new("Checkboxes and radio buttons").text_color(Rgb888::BLACK))
+                .spacing(1)
+                .add(
+                    DefaultTheme::check_box("Check me")
+                        .bind(&checkbox)
+                        .on_selected_changed(|checked, data| {
+                            *data = checked;
+                        }),
+                )
+                .add(
+                    DefaultTheme::check_box("Inactive")
+                        .bind(&checkbox)
+                        .active(false)
+                        .on_data_changed(|checkbox, data| {
+                            checkbox.set_checked(*data);
+                        })
+                        .on_data_changed(|checkbox, data| {
+                            checkbox.set_checked(*data);
+                        }),
+                )
+                .add(
+                    DefaultTheme::radio_button("Can't select me")
+                        .bind(&radio)
+                        .on_selected_changed(|_, data| *data = 0)
+                        .on_data_changed(|radio, data| {
+                            radio.set_checked(*data == 0);
+                        })
+                        .active(false),
+                )
+                .add(
+                    DefaultTheme::radio_button("Select me")
+                        .bind(&radio)
+                        .on_selected_changed(|_, data| *data = 0)
+                        .on_data_changed(|radio, data| {
+                            radio.set_checked(*data == 0);
+                        }),
+                )
+                .add(
+                    DefaultTheme::radio_button("... or me!")
+                        .bind(&radio)
+                        .on_selected_changed(|_, data| *data = 1)
+                        .on_data_changed(|radio, data| {
+                            radio.set_checked(*data == 1);
+                        }),
+                )
+                .add(Spacing::new(Label::new("Numeric sliders")).top(4))
+                .add(
+                    Row::new(FillParent::horizontal(
                         Label::new(String::<U11>::from("0"))
                             .bind(&slider1_data)
                             .on_data_changed(|label, data| {
@@ -154,10 +149,8 @@ fn main() {
                                 write!(label.text, "{}", data).unwrap();
                             }),
                     ))
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
+                    .weight(1)
+                    .add(
                         Spacing::new(
                             DefaultTheme::slider(-100..=100)
                                 .bind(&slider1_data)
@@ -171,11 +164,9 @@ fn main() {
                         .top(1),
                     )
                     .weight(4),
-                ),
-            ))
-            .add(Cell::new(
-                Row::new(
-                    Cell::new(FillParent::horizontal(
+                )
+                .add(
+                    Row::new(FillParent::horizontal(
                         Label::new(String::<U11>::from("0"))
                             .bind(&slider2_data)
                             .on_data_changed(|label, data| {
@@ -183,10 +174,8 @@ fn main() {
                                 write!(label.text, "{}", data).unwrap();
                             }),
                     ))
-                    .weight(1),
-                )
-                .add(
-                    Cell::new(
+                    .weight(1)
+                    .add(
                         Spacing::new(
                             DefaultTheme::slider(0..=5)
                                 .bind(&slider2_data)
@@ -200,26 +189,24 @@ fn main() {
                         .top(1),
                     )
                     .weight(4),
-                ),
-            ))
-            .add(Cell::new(
-                Row::new(Cell::new(Label::new("Inactive"))).add(Cell::new(
-                    Spacing::new(
-                        DefaultTheme::slider(0..=5)
-                            .set_active(false)
-                            .bind(&slider2_data)
-                            .on_value_changed(|data, value| {
-                                *data = value;
-                            })
-                            .on_data_changed(|slider, data| {
-                                slider.set_value(*data);
-                            }),
-                    )
-                    .top(1),
-                )),
-            ))
-            .add(
-                Cell::new(
+                )
+                .add(
+                    Row::new(Label::new("Inactive")).add(
+                        Spacing::new(
+                            DefaultTheme::slider(0..=5)
+                                .set_active(false)
+                                .bind(&slider2_data)
+                                .on_value_changed(|data, value| {
+                                    *data = value;
+                                })
+                                .on_data_changed(|slider, data| {
+                                    slider.set_value(*data);
+                                }),
+                        )
+                        .top(1),
+                    ),
+                )
+                .add(
                     DefaultTheme::primary_button("Reset")
                         .bind(&everything)
                         .on_clicked(|data| {
@@ -230,7 +217,6 @@ fn main() {
                         }),
                 )
                 .weight(1),
-            ),
         )
         .all(2),
     );

--- a/examples/scrolling.rs
+++ b/examples/scrolling.rs
@@ -18,7 +18,7 @@ use embedded_gui::{
     input::event::{InputEvent, PointerEvent, ScrollEvent},
     widgets::{
         label::Label,
-        layouts::linear::{column::Column, row::Row, Cell},
+        layouts::linear::{column::Column, row::Row},
         primitives::{border::Border, fill::FillParent},
         scroll::Scroll,
         slider::ScrollbarConnector,
@@ -85,14 +85,14 @@ fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
 }
 
 fn main() {
-    let display = SimulatorDisplay::new(EgSize::new(128, 64));
+    let display = SimulatorDisplay::new(EgSize::new(128, 96));
 
     let scroll_data = BoundData::new(ScrollbarConnector::new(), |_| ());
     let horizontal_scroll_data = BoundData::new(ScrollbarConnector::new(), |_| ());
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(Cell::new(FillParent::horizontal(
+        Column::new(FillParent::horizontal(
             Label::new("Scroll down")
                 .bind(&scroll_data)
                 .on_data_changed(|label, data| {
@@ -104,9 +104,9 @@ fn main() {
                         "Scroll more"
                     };
                 }),
-        )))
-        .add(Cell::new(
-            Column::new(Cell::new(
+        ))
+        .add(
+            Column::new(
                 Scroll::horizontal(Label::new(
                     "Some very long text that can be used to demonstrate horizontal scrollbars",
                 ))
@@ -114,62 +114,60 @@ fn main() {
                 .bind(&horizontal_scroll_data)
                 .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
                 .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
-            ))
-            .add(Cell::new(
+            )
+            .add(
                 DefaultTheme::horizontal_scrollbar()
                     .bind(&horizontal_scroll_data)
                     .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
                     .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
-            )),
-        ))
-        .add(Cell::new(
-            Row::new(
-                Cell::new(Border::new(
-                    Scroll::vertical(
-                        Column::new(Cell::new(Label::new("S")))
-                            .add(Cell::new(Label::new("c")))
-                            .add(Cell::new(Label::new("r")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("l")))
-                            .add(Cell::new(Label::new("o")))
-                            .add(Cell::new(Label::new("Scrollolo :)")))
-                            .add(Cell::new(
-                                DefaultTheme::primary_button("Reset")
-                                    .bind(&scroll_data)
-                                    .on_clicked(|data| data.scroll_to(0)),
-                            )),
-                    )
-                    .friction(1)
-                    .friction_divisor(2)
-                    .bind(&scroll_data)
-                    .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
-                    .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
-                ))
-                .weight(5),
-            )
-            .add(Cell::new(
+            ),
+        )
+        .add(
+            Row::new(Border::new(
+                Scroll::vertical(
+                    Column::new(Label::new("S"))
+                        .add(Label::new("c"))
+                        .add(Label::new("r"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("l"))
+                        .add(Label::new("o"))
+                        .add(Label::new("Scrollolo :)"))
+                        .add(
+                            DefaultTheme::primary_button("Back to top")
+                                .bind(&scroll_data)
+                                .on_clicked(|data| data.scroll_to(0)),
+                        ),
+                )
+                .friction(1)
+                .friction_divisor(2)
+                .bind(&scroll_data)
+                .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
+                .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
+            ))
+            .weight(8)
+            .add(
                 DefaultTheme::vertical_scrollbar()
                     .bind(&scroll_data)
                     .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
                     .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
-            )),
-        )),
+            ),
+        ),
     );
 
     println!("Size of struct: {}", std::mem::size_of_val(&gui.root));

--- a/examples/scrolling.rs
+++ b/examples/scrolling.rs
@@ -92,7 +92,8 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(FillParent::horizontal(
+        Column::new()
+        .add(FillParent::horizontal(
             Label::new("Scroll down")
                 .bind(&scroll_data)
                 .on_data_changed(|label, data| {
@@ -106,7 +107,8 @@ fn main() {
                 }),
         ))
         .add(
-            Column::new(
+            Column::new()
+            .add(
                 Scroll::horizontal(Label::new(
                     "Some very long text that can be used to demonstrate horizontal scrollbars",
                 ))
@@ -123,50 +125,52 @@ fn main() {
             ),
         )
         .add(
-            Row::new(Border::new(
-                Scroll::vertical(
-                    Column::new(Label::new("S"))
-                        .add(Label::new("c"))
-                        .add(Label::new("r"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("l"))
-                        .add(Label::new("o"))
-                        .add(Label::new("Scrollolo :)"))
-                        .add(
-                            DefaultTheme::primary_button("Back to top")
-                                .bind(&scroll_data)
-                                .on_clicked(|data| data.scroll_to(0)),
-                        ),
-                )
-                .friction(1)
-                .friction_divisor(2)
-                .bind(&scroll_data)
-                .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
-                .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
-            ))
-            .weight(8)
-            .add(
-                DefaultTheme::vertical_scrollbar()
+            Row::new()
+                .add(Border::new(
+                    Scroll::vertical(
+                        Column::new()
+                            .add(Label::new("S"))
+                            .add(Label::new("c"))
+                            .add(Label::new("r"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("Scrollolo :)"))
+                            .add(
+                                DefaultTheme::primary_button("Back to top")
+                                    .bind(&scroll_data)
+                                    .on_clicked(|data| data.scroll_to(0)),
+                            ),
+                    )
+                    .friction(1)
+                    .friction_divisor(2)
                     .bind(&scroll_data)
-                    .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
-                    .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
-            ),
+                    .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
+                    .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
+                ))
+                .weight(8)
+                .add(
+                    DefaultTheme::vertical_scrollbar()
+                        .bind(&scroll_data)
+                        .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
+                        .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
+                ),
         ),
     );
 

--- a/examples/scrolling_rgb.rs
+++ b/examples/scrolling_rgb.rs
@@ -89,85 +89,89 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(FillParent::horizontal(
-            Label::new("Scroll down")
-                .bind(&scroll_data)
-                .on_data_changed(|label, data| {
-                    label.text = if data.offset == data.maximum_offset {
-                        "Scroll back"
-                    } else if data.offset == 0 {
-                        "Scroll down"
-                    } else {
-                        "Scroll more"
-                    };
-                }),
-        ))
-        .add(
-            Column::new(
-                Scroll::horizontal(Label::new(
-                    "Some very long text that can be used to demonstrate horizontal scrollbars",
-                ))
-                .set_active(false)
-                .bind(&horizontal_scroll_data)
-                .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
-                .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
+        Column::new()
+            .add(FillParent::horizontal(
+                Label::new("Scroll down")
+                    .bind(&scroll_data)
+                    .on_data_changed(|label, data| {
+                        label.text = if data.offset == data.maximum_offset {
+                            "Scroll back"
+                        } else if data.offset == 0 {
+                            "Scroll down"
+                        } else {
+                            "Scroll more"
+                        };
+                    }),
+            ))
+            .add(
+                Column::new()
+                .add(
+                    Scroll::horizontal(Label::new(
+                        "Some very long text that can be used to demonstrate horizontal scrollbars",
+                    ))
+                    .set_active(false)
+                    .bind(&horizontal_scroll_data)
+                    .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
+                    .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
+                )
+                .add(
+                    DefaultTheme::horizontal_scrollbar()
+                        .bind(&horizontal_scroll_data)
+                        .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
+                        .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
+                ),
             )
             .add(
-                DefaultTheme::horizontal_scrollbar()
-                    .bind(&horizontal_scroll_data)
-                    .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
-                    .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
-            ),
-        )
-        .add(
-            Row::new(Border::new(
-                Scroll::vertical(
-                    Spacing::new(
-                        Column::new(Label::new("S"))
-                            .add(Label::new("c"))
-                            .add(Label::new("r"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("l"))
-                            .add(Label::new("o"))
-                            .add(Label::new("Scrollolo :)"))
-                            .add(
-                                DefaultTheme::primary_button("Back to top")
-                                    .bind(&scroll_data)
-                                    .on_clicked(|data| data.scroll_to(0)),
-                            ),
+                Row::new()
+                .add(Border::new(
+                    Scroll::vertical(
+                        Spacing::new(
+                            Column::new()
+                            .add(Label::new("S"))
+                                .add(Label::new("c"))
+                                .add(Label::new("r"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("l"))
+                                .add(Label::new("o"))
+                                .add(Label::new("Scrollolo :)"))
+                                .add(
+                                    DefaultTheme::primary_button("Back to top")
+                                        .bind(&scroll_data)
+                                        .on_clicked(|data| data.scroll_to(0)),
+                                ),
+                        )
+                        .all(2),
                     )
-                    .all(2),
-                )
-                .friction(1)
-                .friction_divisor(2)
-                .bind(&scroll_data)
-                .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
-                .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
-            ))
-            .weight(8)
-            .add(
-                DefaultTheme::vertical_scrollbar()
+                    .friction(1)
+                    .friction_divisor(2)
                     .bind(&scroll_data)
-                    .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
-                    .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
+                    .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
+                    .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
+                ))
+                .weight(8)
+                .add(
+                    DefaultTheme::vertical_scrollbar()
+                        .bind(&scroll_data)
+                        .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
+                        .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
+                ),
             ),
-        ),
     );
 
     println!("Size of struct: {}", std::mem::size_of_val(&gui.root));

--- a/examples/scrolling_rgb.rs
+++ b/examples/scrolling_rgb.rs
@@ -15,7 +15,7 @@ use embedded_gui::{
     input::event::{InputEvent, PointerEvent, ScrollEvent},
     widgets::{
         label::Label,
-        layouts::linear::{column::Column, row::Row, Cell},
+        layouts::linear::{column::Column, row::Row},
         primitives::{border::Border, fill::FillParent, spacing::Spacing},
         scroll::Scroll,
         slider::ScrollbarConnector,
@@ -89,7 +89,7 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new(Cell::new(FillParent::horizontal(
+        Column::new(FillParent::horizontal(
             Label::new("Scroll down")
                 .bind(&scroll_data)
                 .on_data_changed(|label, data| {
@@ -101,9 +101,9 @@ fn main() {
                         "Scroll more"
                     };
                 }),
-        )))
-        .add(Cell::new(
-            Column::new(Cell::new(
+        ))
+        .add(
+            Column::new(
                 Scroll::horizontal(Label::new(
                     "Some very long text that can be used to demonstrate horizontal scrollbars",
                 ))
@@ -111,65 +111,63 @@ fn main() {
                 .bind(&horizontal_scroll_data)
                 .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
                 .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
-            ))
-            .add(Cell::new(
+            )
+            .add(
                 DefaultTheme::horizontal_scrollbar()
                     .bind(&horizontal_scroll_data)
                     .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
                     .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
-            )),
-        ))
-        .add(Cell::new(
-            Row::new(
-                Cell::new(Border::new(
-                    Scroll::vertical(
-                        Spacing::new(
-                            Column::new(Cell::new(Label::new("S")))
-                                .add(Cell::new(Label::new("c")))
-                                .add(Cell::new(Label::new("r")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("l")))
-                                .add(Cell::new(Label::new("o")))
-                                .add(Cell::new(Label::new("Scrollolo :)")))
-                                .add(Cell::new(
-                                    DefaultTheme::primary_button("Back to top")
-                                        .bind(&scroll_data)
-                                        .on_clicked(|data| data.scroll_to(0)),
-                                )),
-                        )
-                        .all(2),
+            ),
+        )
+        .add(
+            Row::new(Border::new(
+                Scroll::vertical(
+                    Spacing::new(
+                        Column::new(Label::new("S"))
+                            .add(Label::new("c"))
+                            .add(Label::new("r"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("l"))
+                            .add(Label::new("o"))
+                            .add(Label::new("Scrollolo :)"))
+                            .add(
+                                DefaultTheme::primary_button("Back to top")
+                                    .bind(&scroll_data)
+                                    .on_clicked(|data| data.scroll_to(0)),
+                            ),
                     )
-                    .friction(1)
-                    .friction_divisor(2)
-                    .bind(&scroll_data)
-                    .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
-                    .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
-                ))
-                .weight(8),
-            )
-            .add(Cell::new(
+                    .all(2),
+                )
+                .friction(1)
+                .friction_divisor(2)
+                .bind(&scroll_data)
+                .on_scroll_changed(ScrollbarConnector::on_scroll_widget_scroll_changed)
+                .on_data_changed(ScrollbarConnector::on_scroll_widget_data_changed),
+            ))
+            .weight(8)
+            .add(
                 DefaultTheme::vertical_scrollbar()
                     .bind(&scroll_data)
                     .on_data_changed(ScrollbarConnector::on_scrollbar_data_changed)
                     .on_value_changed(ScrollbarConnector::on_scrollbar_value_changed),
-            )),
-        )),
+            ),
+        ),
     );
 
     println!("Size of struct: {}", std::mem::size_of_val(&gui.root));

--- a/src/widgets/layouts/linear/column.rs
+++ b/src/widgets/layouts/linear/column.rs
@@ -5,30 +5,50 @@ use crate::{
     widgets::{
         layouts::linear::{
             layout::{LayoutDirection, LinearLayout},
-            Cell, CellWeight, NoSpacing, NoWeight,
+            Cell, CellWeight, ElementSpacing, NoSpacing, NoWeight, WithSpacing,
         },
         Widget,
     },
 };
 
 #[derive(Copy, Clone)]
-pub struct Column;
+pub struct Column<ES = NoSpacing>(ES)
+where
+    ES: ElementSpacing;
 
-impl LayoutDirection for Column {
+impl<ES> LayoutDirection for Column<ES>
+where
+    ES: ElementSpacing,
+{
     type AxisOrder = Vertical;
+
+    fn element_spacing(&self) -> u32 {
+        self.0.spacing()
+    }
 }
 
 impl Column {
-    pub fn new<W>(widget: W) -> LinearLayout<Chain<Cell<W, NoWeight>>, Column, NoSpacing>
+    pub fn new() -> Self {
+        Self(NoSpacing)
+    }
+
+    pub fn spacing(self, spacing: u32) -> Column<WithSpacing> {
+        Column(WithSpacing(spacing))
+    }
+}
+
+impl<ES> Column<ES>
+where
+    ES: ElementSpacing,
+{
+    pub fn add<W>(self, widget: W) -> LinearLayout<Chain<Cell<W, NoWeight>>, Self>
     where
         W: Widget,
     {
-        Self::new_cell(Cell::new(widget))
+        self.add_cell(Cell::new(widget))
     }
 
-    pub fn new_cell<W, CW>(
-        widget: Cell<W, CW>,
-    ) -> LinearLayout<Chain<Cell<W, CW>>, Column, NoSpacing>
+    pub fn add_cell<W, CW>(self, widget: Cell<W, CW>) -> LinearLayout<Chain<Cell<W, CW>>, Self>
     where
         W: Widget,
         CW: CellWeight,
@@ -37,8 +57,7 @@ impl Column {
             parent_index: 0,
             bounds: BoundingBox::default(),
             widgets: Chain::new(widget),
-            spacing: NoSpacing,
-            direction: Self,
+            direction: self,
         }
     }
 }

--- a/src/widgets/layouts/linear/column.rs
+++ b/src/widgets/layouts/linear/column.rs
@@ -5,7 +5,7 @@ use crate::{
     widgets::{
         layouts::linear::{
             layout::{LayoutDirection, LinearLayout},
-            Cell, CellWeight, NoSpacing,
+            Cell, CellWeight, NoSpacing, NoWeight,
         },
         Widget,
     },
@@ -19,7 +19,16 @@ impl LayoutDirection for Column {
 }
 
 impl Column {
-    pub fn new<W, CW>(widget: Cell<W, CW>) -> LinearLayout<Chain<Cell<W, CW>>, Column, NoSpacing>
+    pub fn new<W>(widget: W) -> LinearLayout<Chain<Cell<W, NoWeight>>, Column, NoSpacing>
+    where
+        W: Widget,
+    {
+        Self::new_cell(Cell::new(widget))
+    }
+
+    pub fn new_cell<W, CW>(
+        widget: Cell<W, CW>,
+    ) -> LinearLayout<Chain<Cell<W, CW>>, Column, NoSpacing>
     where
         W: Widget,
         CW: CellWeight,

--- a/src/widgets/layouts/linear/layout.rs
+++ b/src/widgets/layouts/linear/layout.rs
@@ -1,4 +1,4 @@
-use object_chain::{ChainElement, Link};
+use object_chain::{Chain, ChainElement, Link};
 
 use crate::{
     geometry::{
@@ -10,7 +10,8 @@ use crate::{
     state::WidgetState,
     widgets::{
         layouts::linear::{
-            Cell, CellWeight, ElementSpacing, LinearLayoutChainElement, NoSpacing, WithSpacing,
+            Cell, CellWeight, ElementSpacing, LinearLayoutChainElement, NoSpacing, NoWeight,
+            Weight, WithSpacing,
         },
         ParentHolder, UpdateHandler, Widget, WidgetStateHolder,
     },
@@ -71,6 +72,44 @@ pub struct LinearLayout<CE, L, ES = NoSpacing> {
     pub widgets: CE,
     pub spacing: ES,
     pub direction: L,
+}
+
+impl<W, CE, L, ES> LinearLayout<Link<Cell<W, NoWeight>, CE>, L, ES>
+where
+    W: Widget,
+    CE: LinearLayoutChainElement + ChainElement,
+    ES: ElementSpacing,
+{
+    pub fn weight(self, weight: u32) -> LinearLayout<Link<Cell<W, Weight>, CE>, L, ES> {
+        LinearLayout {
+            parent_index: self.parent_index,
+            bounds: self.bounds,
+            widgets: Link {
+                object: self.widgets.object.weight(weight),
+                parent: self.widgets.parent,
+            },
+            spacing: self.spacing,
+            direction: self.direction,
+        }
+    }
+}
+
+impl<W, L, ES> LinearLayout<Chain<Cell<W, NoWeight>>, L, ES>
+where
+    W: Widget,
+    ES: ElementSpacing,
+{
+    pub fn weight(self, weight: u32) -> LinearLayout<Chain<Cell<W, Weight>>, L, ES> {
+        LinearLayout {
+            parent_index: self.parent_index,
+            bounds: self.bounds,
+            widgets: Chain {
+                object: self.widgets.object.weight(weight),
+            },
+            spacing: self.spacing,
+            direction: self.direction,
+        }
+    }
 }
 
 impl<CE, L, ES> LinearLayout<CE, L, ES>

--- a/src/widgets/layouts/linear/layout.rs
+++ b/src/widgets/layouts/linear/layout.rs
@@ -117,7 +117,7 @@ where
     CE: LinearLayoutChainElement + ChainElement,
     ES: ElementSpacing,
 {
-    pub fn add<W, CW>(self, widget: Cell<W, CW>) -> LinearLayout<Link<Cell<W, CW>, CE>, L, ES>
+    pub fn add_cell<W, CW>(self, widget: Cell<W, CW>) -> LinearLayout<Link<Cell<W, CW>, CE>, L, ES>
     where
         W: Widget,
         CW: CellWeight,
@@ -129,6 +129,13 @@ where
             spacing: self.spacing,
             direction: self.direction,
         }
+    }
+
+    pub fn add<W>(self, widget: W) -> LinearLayout<Link<Cell<W, NoWeight>, CE>, L, ES>
+    where
+        W: Widget,
+    {
+        self.add_cell(Cell::new(widget))
     }
 
     fn locate(&self, mut idx: usize) -> Option<(usize, usize)> {

--- a/src/widgets/layouts/linear/mod.rs
+++ b/src/widgets/layouts/linear/mod.rs
@@ -11,10 +11,12 @@ pub mod column;
 pub mod layout;
 pub mod row;
 
+#[derive(Copy, Clone)]
 pub struct NoSpacing;
+#[derive(Copy, Clone)]
 pub struct WithSpacing(u32);
 
-pub trait ElementSpacing {
+pub trait ElementSpacing: Copy {
     fn spacing(&self) -> u32;
 }
 

--- a/src/widgets/layouts/linear/row.rs
+++ b/src/widgets/layouts/linear/row.rs
@@ -5,28 +5,50 @@ use crate::{
     widgets::{
         layouts::linear::{
             layout::{LayoutDirection, LinearLayout},
-            Cell, CellWeight, NoSpacing, NoWeight,
+            Cell, CellWeight, ElementSpacing, NoSpacing, NoWeight, WithSpacing,
         },
         Widget,
     },
 };
 
 #[derive(Copy, Clone)]
-pub struct Row;
+pub struct Row<ES = NoSpacing>(ES)
+where
+    ES: ElementSpacing;
 
-impl LayoutDirection for Row {
+impl<ES> LayoutDirection for Row<ES>
+where
+    ES: ElementSpacing,
+{
     type AxisOrder = Horizontal;
+
+    fn element_spacing(&self) -> u32 {
+        self.0.spacing()
+    }
 }
 
 impl Row {
-    pub fn new<W>(widget: W) -> LinearLayout<Chain<Cell<W, NoWeight>>, Row, NoSpacing>
+    pub fn new() -> Self {
+        Self(NoSpacing)
+    }
+
+    pub fn spacing(self, spacing: u32) -> Row<WithSpacing> {
+        Row(WithSpacing(spacing))
+    }
+}
+
+impl<ES> Row<ES>
+where
+    ES: ElementSpacing,
+{
+    pub fn add<W>(self, widget: W) -> LinearLayout<Chain<Cell<W, NoWeight>>, Self>
     where
         W: Widget,
     {
-        Self::new_cell(Cell::new(widget))
+        self.add_cell(Cell::new(widget))
     }
 
-    pub fn new_cell<W, CW>(widget: Cell<W, CW>) -> LinearLayout<Chain<Cell<W, CW>>, Row, NoSpacing>
+    pub fn add_cell<W, CW>(self, widget: Cell<W, CW>) -> LinearLayout<Chain<Cell<W, CW>>, Self>
     where
         W: Widget,
         CW: CellWeight,
@@ -35,8 +57,7 @@ impl Row {
             parent_index: 0,
             bounds: BoundingBox::default(),
             widgets: Chain::new(widget),
-            spacing: NoSpacing,
-            direction: Self,
+            direction: self,
         }
     }
 }

--- a/src/widgets/layouts/linear/row.rs
+++ b/src/widgets/layouts/linear/row.rs
@@ -5,7 +5,7 @@ use crate::{
     widgets::{
         layouts::linear::{
             layout::{LayoutDirection, LinearLayout},
-            Cell, CellWeight, NoSpacing,
+            Cell, CellWeight, NoSpacing, NoWeight,
         },
         Widget,
     },
@@ -19,7 +19,14 @@ impl LayoutDirection for Row {
 }
 
 impl Row {
-    pub fn new<W, CW>(widget: Cell<W, CW>) -> LinearLayout<Chain<Cell<W, CW>>, Row, NoSpacing>
+    pub fn new<W>(widget: W) -> LinearLayout<Chain<Cell<W, NoWeight>>, Row, NoSpacing>
+    where
+        W: Widget,
+    {
+        Self::new_cell(Cell::new(widget))
+    }
+
+    pub fn new_cell<W, CW>(widget: Cell<W, CW>) -> LinearLayout<Chain<Cell<W, CW>>, Row, NoSpacing>
     where
         W: Widget,
         CW: CellWeight,


### PR DESCRIPTION
 - [x] Refactor construction to not take a widget. `Row::new()` should return a `Row`, while `Row::add()` should return a `LinearLayout`
 - [x] Spacing should only be set on `Row`/`Column`
 - [ ] `add()`/`add_weighted()` functions to add widgets?