### PR TITLE
Editable text box

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ object-chain = "0.1"
 [dev-dependencies]
 heapless = "0.7"
 backend-embedded-graphics = {path = "backend-embedded-graphics"}
-embedded-graphics = "0.7.0-beta.2"
-embedded-graphics-simulator = "0.3.0-beta.2"
+embedded-graphics = "0.7.0"
+embedded-graphics-simulator = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ members = [
 
 [dependencies]
 object-chain = "0.1"
+heapless = "0.7"
 
 [dev-dependencies]
-heapless = "0.7"
 backend-embedded-graphics = {path = "backend-embedded-graphics"}
 embedded-graphics = "0.7.0"
 embedded-graphics-simulator = "0.3.0"

--- a/backend-embedded-graphics/Cargo.toml
+++ b/backend-embedded-graphics/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 embedded-graphics = "0.7.0"
 embedded-text = { version = "0.5.0-beta.3", features = ["plugin"] }
 embedded-gui = { path = ".." }
+heapless = "0.7"
+az = "1.1"
 
 [features]
 ansi = ["embedded-text/ansi"]

--- a/backend-embedded-graphics/Cargo.toml
+++ b/backend-embedded-graphics/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 embedded-graphics = "0.7.0"
-embedded-text = { version = "0.5.0-beta.3", features = ["plugin"] }
+# embedded-text = { version = "0.5.0-beta.3", features = ["plugin"] }
+embedded-text = { git = "https://github.com/embedded-graphics/embedded-text", branch = "master", features = ["plugin"] }
 embedded-gui = { path = ".." }
 heapless = "0.7"
 az = "1.1"

--- a/backend-embedded-graphics/Cargo.toml
+++ b/backend-embedded-graphics/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Dániel Buga <bugadani@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-embedded-graphics = "0.7.0-beta.2"
-embedded-text = "0.5.0-beta.2"
+embedded-graphics = "0.7.0"
+embedded-text = { version = "0.5.0-beta.3", features = ["plugin"] }
 embedded-gui = { path = ".." }
 
 [features]

--- a/backend-embedded-graphics/Cargo.toml
+++ b/backend-embedded-graphics/Cargo.toml
@@ -10,6 +10,7 @@ embedded-text = { version = "0.5.0-beta.3", features = ["plugin"] }
 embedded-gui = { path = ".." }
 heapless = "0.7"
 az = "1.1"
+object-chain = "0.1"
 
 [features]
 ansi = ["embedded-text/ansi"]

--- a/backend-embedded-graphics/src/widgets/mod.rs
+++ b/backend-embedded-graphics/src/widgets/mod.rs
@@ -2,4 +2,4 @@ pub mod graphical;
 pub mod label;
 pub mod primitives;
 pub mod scroll;
-pub mod textbox;
+pub mod text_block;

--- a/backend-embedded-graphics/src/widgets/mod.rs
+++ b/backend-embedded-graphics/src/widgets/mod.rs
@@ -3,3 +3,4 @@ pub mod label;
 pub mod primitives;
 pub mod scroll;
 pub mod text_block;
+pub mod text_box;

--- a/backend-embedded-graphics/src/widgets/text_block/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_block/mod.rs
@@ -9,7 +9,7 @@ use embedded_graphics::{
 };
 use embedded_gui::{
     geometry::{measurement::MeasureSpec, MeasuredSize},
-    widgets::textbox::{TextBox, TextBoxProperties},
+    widgets::text_block::{TextBlock, TextBlockProperties},
     WidgetRenderer,
 };
 use embedded_text::{
@@ -21,7 +21,7 @@ pub use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
 
 use crate::{EgCanvas, ToRectangle};
 
-pub struct TextBoxStyle<T>
+pub struct TextBlockStyle<T>
 where
     T: TextRenderer + CharacterStyle<Color = <T as TextRenderer>::Color>,
 {
@@ -30,7 +30,7 @@ where
     vertical: VerticalAlignment,
 }
 
-impl<'a, 'b, 'c, C> TextBoxStyle<MonoTextStyle<'a, C>>
+impl<'a, 'b, 'c, C> TextBlockStyle<MonoTextStyle<'a, C>>
 where
     C: PixelColor,
 {
@@ -42,8 +42,8 @@ where
     }
 
     /// Customize the font
-    pub fn font<'a2>(self, font: &'a2 MonoFont<'a2>) -> TextBoxStyle<MonoTextStyle<'a2, C>> {
-        TextBoxStyle {
+    pub fn font<'a2>(self, font: &'a2 MonoFont<'a2>) -> TextBlockStyle<MonoTextStyle<'a2, C>> {
+        TextBlockStyle {
             renderer: MonoTextStyleBuilder::from(&self.renderer)
                 .font(font)
                 .build(),
@@ -53,7 +53,7 @@ where
     }
 }
 
-impl<F, C> TextBoxProperties for TextBoxStyle<F>
+impl<F, C> TextBlockProperties for TextBlockStyle<F>
 where
     F: TextRenderer<Color = C> + CharacterStyle<Color = C>,
     C: PixelColor + From<Rgb888>,
@@ -87,7 +87,7 @@ where
     }
 }
 
-pub trait TextBoxStyling<'a, C, S, T>: Sized
+pub trait TextBlockStyling<'a, C, S, T>: Sized
 where
     C: PixelColor,
     T: TextRenderer + CharacterStyle<Color = <T as TextRenderer>::Color>,
@@ -101,22 +101,22 @@ where
 
     fn set_text_color(&mut self, color: Self::Color);
 
-    fn text_renderer<T2>(self, renderer: T2) -> TextBox<S, TextBoxStyle<T2>>
+    fn text_renderer<T2>(self, renderer: T2) -> TextBlock<S, TextBlockStyle<T2>>
     where
         T2: TextRenderer + CharacterStyle<Color = <T2 as TextRenderer>::Color>,
         <T2 as TextRenderer>::Color: From<Rgb888>;
 
-    fn style<P>(self, props: P) -> TextBox<S, P>
+    fn style<P>(self, props: P) -> TextBlock<S, P>
     where
-        P: TextBoxProperties;
+        P: TextBlockProperties;
 
     fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self;
 
     fn vertical_alignment(self, alignment: VerticalAlignment) -> Self;
 }
 
-impl<'a, C, S> TextBoxStyling<'a, C, S, MonoTextStyle<'a, C>>
-    for TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>
+impl<'a, C, S> TextBlockStyling<'a, C, S, MonoTextStyle<'a, C>>
+    for TextBlock<S, TextBlockStyle<MonoTextStyle<'a, C>>>
 where
     S: AsRef<str>,
     C: PixelColor + From<Rgb888>,
@@ -127,7 +127,7 @@ where
         self.label_properties.text_color(color);
     }
 
-    fn text_renderer<T>(self, renderer: T) -> TextBox<S, TextBoxStyle<T>>
+    fn text_renderer<T>(self, renderer: T) -> TextBlock<S, TextBlockStyle<T>>
     where
         T: TextRenderer + CharacterStyle<Color = <T as TextRenderer>::Color>,
         <T as TextRenderer>::Color: From<Rgb888>,
@@ -135,18 +135,18 @@ where
         let horizontal = self.label_properties.horizontal;
         let vertical = self.label_properties.vertical;
 
-        self.style(TextBoxStyle {
+        self.style(TextBlockStyle {
             renderer,
             horizontal,
             vertical,
         })
     }
 
-    fn style<P>(self, props: P) -> TextBox<S, P>
+    fn style<P>(self, props: P) -> TextBlock<S, P>
     where
-        P: TextBoxProperties,
+        P: TextBlockProperties,
     {
-        TextBox {
+        TextBlock {
             parent_index: self.parent_index,
             text: self.text,
             bounds: self.bounds,
@@ -160,7 +160,7 @@ where
         let horizontal = alignment;
         let vertical = self.label_properties.vertical;
 
-        self.style(TextBoxStyle {
+        self.style(TextBlockStyle {
             renderer,
             horizontal,
             vertical,
@@ -172,7 +172,7 @@ where
         let horizontal = self.label_properties.horizontal;
         let vertical = alignment;
 
-        self.style(TextBoxStyle {
+        self.style(TextBlockStyle {
             renderer,
             horizontal,
             vertical,
@@ -181,15 +181,16 @@ where
 }
 
 /// Font settings specific to `MonoFont`'s renderer.
-pub trait MonoFontTextBoxStyling<C, S>: Sized
+pub trait MonoFontTextBlockStyling<C, S>: Sized
 where
     S: AsRef<str>,
     C: PixelColor,
 {
-    fn font<'a>(self, font: &'a MonoFont<'a>) -> TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>;
+    fn font<'a>(self, font: &'a MonoFont<'a>)
+        -> TextBlock<S, TextBlockStyle<MonoTextStyle<'a, C>>>;
 }
 
-impl<'a, C, S> MonoFontTextBoxStyling<C, S> for TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>
+impl<'a, C, S> MonoFontTextBlockStyling<C, S> for TextBlock<S, TextBlockStyle<MonoTextStyle<'a, C>>>
 where
     S: AsRef<str>,
     C: PixelColor + From<Rgb888>,
@@ -197,14 +198,14 @@ where
     fn font<'a2>(
         self,
         font: &'a2 MonoFont<'a2>,
-    ) -> TextBox<S, TextBoxStyle<MonoTextStyle<'a2, C>>> {
+    ) -> TextBlock<S, TextBlockStyle<MonoTextStyle<'a2, C>>> {
         let renderer = MonoTextStyleBuilder::from(&self.label_properties.renderer)
             .font(font)
             .build();
         let horizontal = self.label_properties.horizontal;
         let vertical = self.label_properties.vertical;
 
-        self.style(TextBoxStyle {
+        self.style(TextBlockStyle {
             renderer,
             horizontal,
             vertical,
@@ -212,7 +213,7 @@ where
     }
 }
 
-impl<S, F, C, DT> WidgetRenderer<EgCanvas<DT>> for TextBox<S, TextBoxStyle<F>>
+impl<S, F, C, DT> WidgetRenderer<EgCanvas<DT>> for TextBlock<S, TextBlockStyle<F>>
 where
     S: AsRef<str>,
     F: TextRenderer<Color = C> + CharacterStyle<Color = C>,
@@ -242,30 +243,30 @@ macro_rules! textbox_for_charset {
                 mono_font::{$charset, MonoTextStyle},
                 pixelcolor::PixelColor,
             };
-            use embedded_gui::{geometry::BoundingBox, widgets::textbox::TextBox};
+            use embedded_gui::{geometry::BoundingBox, widgets::text_block::TextBlock};
             use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
 
-            use crate::{themes::Theme, widgets::textbox::TextBoxStyle};
+            use crate::{themes::Theme, widgets::text_block::TextBlockStyle};
 
-            pub trait TextBoxConstructor<'a, S, C>
+            pub trait TextBlockConstructor<'a, S, C>
             where
                 S: AsRef<str>,
                 C: PixelColor,
             {
-                fn new(text: S) -> TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>;
+                fn new(text: S) -> TextBlock<S, TextBlockStyle<MonoTextStyle<'a, C>>>;
             }
 
-            impl<'a, 'b, 'c, C, S> TextBoxConstructor<'a, S, C>
-                for TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>
+            impl<'a, 'b, 'c, C, S> TextBlockConstructor<'a, S, C>
+                for TextBlock<S, TextBlockStyle<MonoTextStyle<'a, C>>>
             where
                 S: AsRef<str>,
                 C: PixelColor + Theme,
             {
                 fn new(text: S) -> Self {
-                    TextBox {
+                    TextBlock {
                         parent_index: 0,
                         text,
-                        label_properties: TextBoxStyle {
+                        label_properties: TextBlockStyle {
                             renderer: MonoTextStyle::new(
                                 &$charset::$font,
                                 <C as Theme>::TEXT_COLOR,

--- a/backend-embedded-graphics/src/widgets/text_block/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_block/mod.rs
@@ -31,17 +31,21 @@ where
     vertical: VerticalAlignment,
 }
 
+impl<C, T> TextBlockStyle<T>
+where
+    C: PixelColor,
+    T: TextRenderer<Color = C> + CharacterStyle<Color = C>,
+{
+    /// Customize the text color
+    pub fn text_color(&mut self, text_color: C) {
+        self.renderer.set_text_color(Some(text_color));
+    }
+}
+
 impl<'a, C> TextBlockStyle<MonoTextStyle<'a, C>>
 where
     C: PixelColor,
 {
-    /// Customize the text color
-    pub fn text_color(&mut self, text_color: C) {
-        self.renderer = MonoTextStyleBuilder::from(&self.renderer)
-            .text_color(text_color)
-            .build();
-    }
-
     /// Customize the font
     pub fn font<'a2>(self, font: &'a2 MonoFont<'a2>) -> TextBlockStyle<MonoTextStyle<'a2, C>> {
         TextBlockStyle {
@@ -83,7 +87,8 @@ where
 pub trait TextBlockStyling<'a, C, S, T>: Sized
 where
     C: PixelColor,
-    T: TextRenderer + CharacterStyle<Color = <T as TextRenderer>::Color>,
+    T: CharacterStyle<Color = C>,
+    T: TextRenderer<Color = C>,
 {
     type Color;
 

--- a/backend-embedded-graphics/src/widgets/text_block/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_block/mod.rs
@@ -13,6 +13,7 @@ use embedded_gui::{
     WidgetRenderer,
 };
 use embedded_text::{
+    plugin::ansi::Ansi,
     style::{HeightMode, TextBoxStyleBuilder, VerticalOverdraw},
     TextBox as EgTextBox,
 };
@@ -231,6 +232,7 @@ where
                 .vertical_alignment(self.label_properties.vertical)
                 .build(),
         )
+        .add_plugin(Ansi::new())
         .draw(&mut canvas.target)
         .map(|_| ())
     }

--- a/backend-embedded-graphics/src/widgets/text_block/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_block/mod.rs
@@ -31,7 +31,7 @@ where
     vertical: VerticalAlignment,
 }
 
-impl<'a, 'b, 'c, C> TextBlockStyle<MonoTextStyle<'a, C>>
+impl<'a, C> TextBlockStyle<MonoTextStyle<'a, C>>
 where
     C: PixelColor,
 {

--- a/backend-embedded-graphics/src/widgets/text_block/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_block/mod.rs
@@ -63,22 +63,14 @@ where
         let max_width = spec.width.largest().unwrap_or(u32::MAX);
         let max_height = spec.height.largest().unwrap_or(u32::MAX);
 
-        if spec.height.is_exact() {
-            return MeasuredSize {
-                width: max_width,
-                height: spec.height.largest().unwrap(),
-            };
-        }
-
         let bounding_box = EgTextBox::with_textbox_style(
             text,
             Rectangle::new(Point::zero(), Size::new(max_width, max_height)),
             self.renderer.clone(),
             TextBoxStyleBuilder::new()
-                .height_mode(HeightMode::ShrinkToText(VerticalOverdraw::Hidden))
+                .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
                 .build(),
         )
-        .fit_height()
         .bounding_box();
 
         MeasuredSize {

--- a/backend-embedded-graphics/src/widgets/text_box/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/mod.rs
@@ -2,13 +2,14 @@ use embedded_graphics::{
     draw_target::DrawTarget,
     mono_font::{MonoFont, MonoTextStyle, MonoTextStyleBuilder},
     pixelcolor::{PixelColor, Rgb888},
-    prelude::{Dimensions, Point, Size},
-    primitives::Rectangle,
+    prelude::{Dimensions, Point, Size, WebColors},
+    primitives::{PrimitiveStyle, Rectangle, StyledDrawable},
     text::renderer::{CharacterStyle, TextRenderer},
     Drawable,
 };
 use embedded_gui::{
     geometry::{measurement::MeasureSpec, MeasuredSize},
+    state::selection::Selected,
     widgets::text_box::{TextBox, TextBoxProperties},
     WidgetRenderer,
 };
@@ -147,6 +148,7 @@ where
         P: TextBoxProperties,
     {
         TextBox {
+            state: self.state,
             parent_index: self.parent_index,
             text: self.text,
             bounds: self.bounds,
@@ -220,6 +222,13 @@ where
     DT: DrawTarget<Color = C>,
 {
     fn draw(&self, canvas: &mut EgCanvas<DT>) -> Result<(), DT::Error> {
+        if self.state.has_state(Selected) {
+            self.bounds.to_rectangle().draw_styled(
+                &PrimitiveStyle::with_stroke(Rgb888::CSS_DODGER_BLUE.into(), 1),
+                &mut canvas.target,
+            )?;
+        }
+
         EgTextBox::with_textbox_style(
             self.text.as_ref(),
             self.bounds.to_rectangle(),
@@ -242,7 +251,9 @@ macro_rules! textbox_for_charset {
                 mono_font::{$charset, MonoTextStyle},
                 pixelcolor::PixelColor,
             };
-            use embedded_gui::{geometry::BoundingBox, widgets::text_box::TextBox};
+            use embedded_gui::{
+                geometry::BoundingBox, state::WidgetState, widgets::text_box::TextBox,
+            };
             use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
 
             use crate::{themes::Theme, widgets::text_box::TextBoxStyle};
@@ -263,6 +274,7 @@ macro_rules! textbox_for_charset {
             {
                 fn new(text: S) -> Self {
                     TextBox {
+                        state: WidgetState::default(),
                         parent_index: 0,
                         text,
                         label_properties: TextBoxStyle {

--- a/backend-embedded-graphics/src/widgets/text_box/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/mod.rs
@@ -38,8 +38,9 @@ where
     T: TextRenderer + CharacterStyle<Color = <T as TextRenderer>::Color>,
 {
     renderer: T,
-    horizontal: HorizontalAlignment,
-    vertical: VerticalAlignment,
+    // Temporarily removed as alignments and editor together are a bit buggy
+    // horizontal: HorizontalAlignment,
+    // vertical: VerticalAlignment,
     cursor: Cell<Cursor>,
     cursor_color: Option<<T as TextRenderer>::Color>,
 }
@@ -78,8 +79,8 @@ where
             renderer: MonoTextStyleBuilder::from(&self.renderer)
                 .font(font)
                 .build(),
-            horizontal: self.horizontal,
-            vertical: self.vertical,
+            // horizontal: self.horizontal,
+            // vertical: self.vertical,
             cursor: Cell::new(Cursor::default()),
             cursor_color: None,
         }
@@ -167,9 +168,9 @@ where
     where
         P: TextBoxProperties;
 
-    fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self;
+    // fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self;
 
-    fn vertical_alignment(self, alignment: VerticalAlignment) -> Self;
+    // fn vertical_alignment(self, alignment: VerticalAlignment) -> Self;
 
     fn cursor_color(self, color: Self::Color) -> Self;
 }
@@ -192,14 +193,14 @@ where
         T2: TextRenderer + CharacterStyle<Color = <T2 as TextRenderer>::Color>,
         <T2 as TextRenderer>::Color: From<Rgb888>,
     {
-        let horizontal = self.fields.label_properties.horizontal;
-        let vertical = self.fields.label_properties.vertical;
+        // let horizontal = self.fields.label_properties.horizontal;
+        // let vertical = self.fields.label_properties.vertical;
         let cursor = self.fields.label_properties.cursor.clone();
 
         self.style(TextBoxStyle {
             renderer,
-            horizontal,
-            vertical,
+            // horizontal,
+            // vertical,
             cursor,
             cursor_color: None, // TODO: convert
         })
@@ -222,49 +223,49 @@ where
         }
     }
 
-    fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self {
-        let renderer = self.fields.label_properties.renderer.clone();
-        let horizontal = alignment;
-        let vertical = self.fields.label_properties.vertical;
-        let cursor = self.fields.label_properties.cursor.clone();
-        let cursor_color = self.fields.label_properties.cursor_color;
-
-        self.style(TextBoxStyle {
-            renderer,
-            horizontal,
-            vertical,
-            cursor,
-            cursor_color,
-        })
-    }
-
-    fn vertical_alignment(self, alignment: VerticalAlignment) -> Self {
-        let renderer = self.fields.label_properties.renderer.clone();
-        let horizontal = self.fields.label_properties.horizontal;
-        let vertical = alignment;
-        let cursor = self.fields.label_properties.cursor.clone();
-        let cursor_color = self.fields.label_properties.cursor_color;
-
-        self.style(TextBoxStyle {
-            renderer,
-            horizontal,
-            vertical,
-            cursor,
-            cursor_color,
-        })
-    }
+    // fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self {
+    //     let renderer = self.fields.label_properties.renderer.clone();
+    //     let horizontal = alignment;
+    //     let vertical = self.fields.label_properties.vertical;
+    //     let cursor = self.fields.label_properties.cursor.clone();
+    //     let cursor_color = self.fields.label_properties.cursor_color;
+    //
+    //     self.style(TextBoxStyle {
+    //         renderer,
+    //         horizontal,
+    //         vertical,
+    //         cursor,
+    //         cursor_color,
+    //     })
+    // }
+    //
+    // fn vertical_alignment(self, alignment: VerticalAlignment) -> Self {
+    //     let renderer = self.fields.label_properties.renderer.clone();
+    //     let horizontal = self.fields.label_properties.horizontal;
+    //     let vertical = alignment;
+    //     let cursor = self.fields.label_properties.cursor.clone();
+    //     let cursor_color = self.fields.label_properties.cursor_color;
+    //
+    //     self.style(TextBoxStyle {
+    //         renderer,
+    //         horizontal,
+    //         vertical,
+    //         cursor,
+    //         cursor_color,
+    //     })
+    // }
 
     fn cursor_color(self, color: C) -> Self {
         let renderer = self.fields.label_properties.renderer.clone();
-        let horizontal = self.fields.label_properties.horizontal;
-        let vertical = self.fields.label_properties.vertical;
+        // let horizontal = self.fields.label_properties.horizontal;
+        // let vertical = self.fields.label_properties.vertical;
         let cursor = self.fields.label_properties.cursor.clone();
         let cursor_color = Some(color);
 
         self.style(TextBoxStyle {
             renderer,
-            horizontal,
-            vertical,
+            // horizontal,
+            // vertical,
             cursor,
             cursor_color,
         })
@@ -293,15 +294,15 @@ where
         let renderer = MonoTextStyleBuilder::from(&self.fields.label_properties.renderer)
             .font(font)
             .build();
-        let horizontal = self.fields.label_properties.horizontal;
-        let vertical = self.fields.label_properties.vertical;
+        // let horizontal = self.fields.label_properties.horizontal;
+        // let vertical = self.fields.label_properties.vertical;
         let cursor = self.fields.label_properties.cursor.clone();
         let cursor_color = self.fields.label_properties.cursor_color;
 
         self.style(TextBoxStyle {
             renderer,
-            horizontal,
-            vertical,
+            // horizontal,
+            // vertical,
             cursor,
             cursor_color,
         })
@@ -317,18 +318,20 @@ where
 {
     fn draw(&self, canvas: &mut EgCanvas<DT>) -> Result<(), DT::Error> {
         let cursor_color = self.fields.label_properties.cursor_color;
+
+        let textbox = EgTextBox::with_textbox_style(
+            self.fields.text.as_ref(),
+            self.fields.bounds.to_rectangle(),
+            self.fields.label_properties.renderer.clone(),
+            TextBoxStyleBuilder::new()
+                .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
+                // .alignment(self.fields.label_properties.horizontal)
+                // .vertical_alignment(self.fields.label_properties.vertical)
+                .build(),
+        );
+
         if self.fields.state.has_state(Selected) && cursor_color.is_some() {
-            let textbox = EgTextBox::with_textbox_style(
-                self.fields.text.as_ref(),
-                self.fields.bounds.to_rectangle(),
-                self.fields.label_properties.renderer.clone(),
-                TextBoxStyleBuilder::new()
-                    .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
-                    .alignment(self.fields.label_properties.horizontal)
-                    .vertical_alignment(self.fields.label_properties.vertical)
-                    .build(),
-            )
-            .add_plugin(
+            let textbox = textbox.add_plugin(
                 self.fields
                     .label_properties
                     .cursor
@@ -343,18 +346,7 @@ where
 
             result
         } else {
-            EgTextBox::with_textbox_style(
-                self.fields.text.as_ref(),
-                self.fields.bounds.to_rectangle(),
-                self.fields.label_properties.renderer.clone(),
-                TextBoxStyleBuilder::new()
-                    .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
-                    .alignment(self.fields.label_properties.horizontal)
-                    .vertical_alignment(self.fields.label_properties.vertical)
-                    .build(),
-            )
-            .draw(&mut canvas.target)
-            .map(|_| ())
+            textbox.draw(&mut canvas.target).map(|_| ())
         }
     }
 }
@@ -376,7 +368,7 @@ macro_rules! textbox_for_charset {
                     WidgetDataHolder,
                 },
             };
-            use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
+            // use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
 
             use crate::{
                 themes::Theme,
@@ -409,8 +401,8 @@ macro_rules! textbox_for_charset {
                                     &$charset::$font,
                                     <C as Theme>::TEXT_COLOR,
                                 ),
-                                horizontal: HorizontalAlignment::Left,
-                                vertical: VerticalAlignment::Top,
+                                // horizontal: HorizontalAlignment::Left,
+                                // vertical: VerticalAlignment::Top,
                                 cursor: Cell::new(Cursor::default()),
                                 cursor_color: Some(<C as Theme>::TEXT_COLOR),
                             },

--- a/backend-embedded-graphics/src/widgets/text_box/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/mod.rs
@@ -221,24 +221,33 @@ where
 {
     fn draw(&self, canvas: &mut EgCanvas<DT>) -> Result<(), DT::Error> {
         if self.state.has_state(Selected) {
-            self.bounds.to_rectangle().draw_styled(
-                &PrimitiveStyle::with_stroke(Rgb888::CSS_DODGER_BLUE.into(), 1),
-                &mut canvas.target,
-            )?;
+            EgTextBox::with_textbox_style(
+                self.text.as_ref(),
+                self.bounds.to_rectangle(),
+                self.label_properties.renderer.clone(),
+                TextBoxStyleBuilder::new()
+                    .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
+                    .alignment(self.label_properties.horizontal)
+                    .vertical_alignment(self.label_properties.vertical)
+                    .build(),
+            )
+            //.add_plugin(self.editor_input.plugin())
+            .draw(&mut canvas.target)
+            .map(|_| ())
+        } else {
+            EgTextBox::with_textbox_style(
+                self.text.as_ref(),
+                self.bounds.to_rectangle(),
+                self.label_properties.renderer.clone(),
+                TextBoxStyleBuilder::new()
+                    .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
+                    .alignment(self.label_properties.horizontal)
+                    .vertical_alignment(self.label_properties.vertical)
+                    .build(),
+            )
+            .draw(&mut canvas.target)
+            .map(|_| ())
         }
-
-        EgTextBox::with_textbox_style(
-            self.text.as_ref(),
-            self.bounds.to_rectangle(),
-            self.label_properties.renderer.clone(),
-            TextBoxStyleBuilder::new()
-                .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
-                .alignment(self.label_properties.horizontal)
-                .vertical_alignment(self.label_properties.vertical)
-                .build(),
-        )
-        .draw(&mut canvas.target)
-        .map(|_| ())
     }
 }
 

--- a/backend-embedded-graphics/src/widgets/text_box/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/mod.rs
@@ -91,19 +91,12 @@ where
         let max_width = spec.width.largest().unwrap_or(u32::MAX);
         let max_height = spec.height.largest().unwrap_or(u32::MAX);
 
-        if spec.height.is_exact() {
-            return MeasuredSize {
-                width: max_width,
-                height: spec.height.largest().unwrap(),
-            };
-        }
-
         let bounding_box = EgTextBox::with_textbox_style(
             text,
             Rectangle::new(Point::zero(), Size::new(max_width, max_height)),
             self.renderer.clone(),
             TextBoxStyleBuilder::new()
-                .height_mode(HeightMode::ShrinkToText(VerticalOverdraw::Hidden))
+                .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
                 .build(),
         )
         .fit_height()

--- a/backend-embedded-graphics/src/widgets/text_box/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/mod.rs
@@ -153,7 +153,6 @@ where
             text: self.text,
             bounds: self.bounds,
             label_properties: props,
-            on_state_changed: |_, _| (),
         }
     }
 
@@ -286,7 +285,6 @@ macro_rules! textbox_for_charset {
                             vertical: VerticalAlignment::Top,
                         },
                         bounds: BoundingBox::default(),
-                        on_state_changed: |_, _| (),
                     }
                 }
             }

--- a/backend-embedded-graphics/src/widgets/text_box/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/mod.rs
@@ -102,6 +102,8 @@ where
             self.renderer.clone(),
             TextBoxStyleBuilder::new()
                 .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
+                .leading_spaces(true)
+                .trailing_spaces(true)
                 .build(),
         )
         .fit_height()
@@ -325,6 +327,8 @@ where
             self.fields.label_properties.renderer.clone(),
             TextBoxStyleBuilder::new()
                 .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
+                .leading_spaces(true)
+                .trailing_spaces(true)
                 // .alignment(self.fields.label_properties.horizontal)
                 // .vertical_alignment(self.fields.label_properties.vertical)
                 .build(),

--- a/backend-embedded-graphics/src/widgets/text_box/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/mod.rs
@@ -10,7 +10,8 @@ use embedded_graphics::{
     Drawable,
 };
 use embedded_gui::{
-    geometry::{measurement::MeasureSpec, MeasuredSize},
+    geometry::{measurement::MeasureSpec, MeasuredSize, Position},
+    input::event::{Key, Modifier, ToStr},
     state::selection::Selected,
     widgets::text_box::{TextBox, TextBoxProperties},
     WidgetRenderer,
@@ -21,9 +22,10 @@ use embedded_text::{
 };
 
 pub use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
+use heapless::String;
 use object_chain::Chain;
 
-use crate::{widgets::text_box::plugin::Cursor, EgCanvas, ToRectangle};
+use crate::{widgets::text_box::plugin::Cursor, EgCanvas, ToPoint, ToRectangle};
 
 mod plugin;
 
@@ -107,6 +109,33 @@ where
             width: bounding_box.size.width,
             height: bounding_box.size.height,
         }
+    }
+
+    fn handle_keypress<const N: usize>(
+        &mut self,
+        key: Key,
+        modifier: Modifier,
+        text: &mut String<N>,
+    ) {
+        let cursor = self.cursor.get_mut();
+
+        match key {
+            Key::ArrowUp => cursor.cursor_up(),
+            Key::ArrowDown => cursor.cursor_down(),
+            Key::ArrowLeft => cursor.cursor_left(),
+            Key::ArrowRight => cursor.cursor_right(),
+            Key::Del => cursor.delete_after(text),
+            Key::Backspace => cursor.delete_before(text),
+            _ => {
+                if let Some(str) = (key, modifier).to_str() {
+                    cursor.insert(text, str);
+                }
+            }
+        }
+    }
+
+    fn handle_cursor_down(&mut self, coordinates: Position) {
+        self.cursor.get_mut().move_cursor_to(coordinates.to_point())
     }
 }
 

--- a/backend-embedded-graphics/src/widgets/text_box/mod.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/mod.rs
@@ -1,0 +1,302 @@
+use embedded_graphics::{
+    draw_target::DrawTarget,
+    mono_font::{MonoFont, MonoTextStyle, MonoTextStyleBuilder},
+    pixelcolor::{PixelColor, Rgb888},
+    prelude::{Dimensions, Point, Size},
+    primitives::Rectangle,
+    text::renderer::{CharacterStyle, TextRenderer},
+    Drawable,
+};
+use embedded_gui::{
+    geometry::{measurement::MeasureSpec, MeasuredSize},
+    widgets::text_box::{TextBox, TextBoxProperties},
+    WidgetRenderer,
+};
+use embedded_text::{
+    style::{HeightMode, TextBoxStyleBuilder, VerticalOverdraw},
+    TextBox as EgTextBox,
+};
+
+pub use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
+
+use crate::{EgCanvas, ToRectangle};
+
+pub struct TextBoxStyle<T>
+where
+    T: TextRenderer + CharacterStyle<Color = <T as TextRenderer>::Color>,
+{
+    renderer: T,
+    horizontal: HorizontalAlignment,
+    vertical: VerticalAlignment,
+}
+
+impl<'a, 'b, 'c, C> TextBoxStyle<MonoTextStyle<'a, C>>
+where
+    C: PixelColor,
+{
+    /// Customize the text color
+    pub fn text_color(&mut self, text_color: C) {
+        self.renderer = MonoTextStyleBuilder::from(&self.renderer)
+            .text_color(text_color)
+            .build();
+    }
+
+    /// Customize the font
+    pub fn font<'a2>(self, font: &'a2 MonoFont<'a2>) -> TextBoxStyle<MonoTextStyle<'a2, C>> {
+        TextBoxStyle {
+            renderer: MonoTextStyleBuilder::from(&self.renderer)
+                .font(font)
+                .build(),
+            horizontal: self.horizontal,
+            vertical: self.vertical,
+        }
+    }
+}
+
+impl<F, C> TextBoxProperties for TextBoxStyle<F>
+where
+    F: TextRenderer<Color = C> + CharacterStyle<Color = C>,
+    C: PixelColor + From<Rgb888>,
+{
+    fn measure_text(&self, text: &str, spec: MeasureSpec) -> MeasuredSize {
+        let max_width = spec.width.largest().unwrap_or(u32::MAX);
+        let max_height = spec.height.largest().unwrap_or(u32::MAX);
+
+        if spec.height.is_exact() {
+            return MeasuredSize {
+                width: max_width,
+                height: spec.height.largest().unwrap(),
+            };
+        }
+
+        let bounding_box = EgTextBox::with_textbox_style(
+            text,
+            Rectangle::new(Point::zero(), Size::new(max_width, max_height)),
+            self.renderer.clone(),
+            TextBoxStyleBuilder::new()
+                .height_mode(HeightMode::ShrinkToText(VerticalOverdraw::Hidden))
+                .build(),
+        )
+        .fit_height()
+        .bounding_box();
+
+        MeasuredSize {
+            width: bounding_box.size.width,
+            height: bounding_box.size.height,
+        }
+    }
+}
+
+pub trait TextBoxStyling<'a, C, S, T>: Sized
+where
+    C: PixelColor,
+    T: TextRenderer + CharacterStyle<Color = <T as TextRenderer>::Color>,
+{
+    type Color;
+
+    fn text_color(mut self, color: Self::Color) -> Self {
+        self.set_text_color(color);
+        self
+    }
+
+    fn set_text_color(&mut self, color: Self::Color);
+
+    fn text_renderer<T2>(self, renderer: T2) -> TextBox<S, TextBoxStyle<T2>>
+    where
+        T2: TextRenderer + CharacterStyle<Color = <T2 as TextRenderer>::Color>,
+        <T2 as TextRenderer>::Color: From<Rgb888>;
+
+    fn style<P>(self, props: P) -> TextBox<S, P>
+    where
+        P: TextBoxProperties;
+
+    fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self;
+
+    fn vertical_alignment(self, alignment: VerticalAlignment) -> Self;
+}
+
+impl<'a, C, S> TextBoxStyling<'a, C, S, MonoTextStyle<'a, C>>
+    for TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>
+where
+    S: AsRef<str>,
+    C: PixelColor + From<Rgb888>,
+{
+    type Color = C;
+
+    fn set_text_color(&mut self, color: Self::Color) {
+        self.label_properties.text_color(color);
+    }
+
+    fn text_renderer<T>(self, renderer: T) -> TextBox<S, TextBoxStyle<T>>
+    where
+        T: TextRenderer + CharacterStyle<Color = <T as TextRenderer>::Color>,
+        <T as TextRenderer>::Color: From<Rgb888>,
+    {
+        let horizontal = self.label_properties.horizontal;
+        let vertical = self.label_properties.vertical;
+
+        self.style(TextBoxStyle {
+            renderer,
+            horizontal,
+            vertical,
+        })
+    }
+
+    fn style<P>(self, props: P) -> TextBox<S, P>
+    where
+        P: TextBoxProperties,
+    {
+        TextBox {
+            parent_index: self.parent_index,
+            text: self.text,
+            bounds: self.bounds,
+            label_properties: props,
+            on_state_changed: |_, _| (),
+        }
+    }
+
+    fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self {
+        let renderer = self.label_properties.renderer;
+        let horizontal = alignment;
+        let vertical = self.label_properties.vertical;
+
+        self.style(TextBoxStyle {
+            renderer,
+            horizontal,
+            vertical,
+        })
+    }
+
+    fn vertical_alignment(self, alignment: VerticalAlignment) -> Self {
+        let renderer = self.label_properties.renderer;
+        let horizontal = self.label_properties.horizontal;
+        let vertical = alignment;
+
+        self.style(TextBoxStyle {
+            renderer,
+            horizontal,
+            vertical,
+        })
+    }
+}
+
+/// Font settings specific to `MonoFont`'s renderer.
+pub trait MonoFontTextBoxStyling<C, S>: Sized
+where
+    S: AsRef<str>,
+    C: PixelColor,
+{
+    fn font<'a>(self, font: &'a MonoFont<'a>) -> TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>;
+}
+
+impl<'a, C, S> MonoFontTextBoxStyling<C, S> for TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>
+where
+    S: AsRef<str>,
+    C: PixelColor + From<Rgb888>,
+{
+    fn font<'a2>(
+        self,
+        font: &'a2 MonoFont<'a2>,
+    ) -> TextBox<S, TextBoxStyle<MonoTextStyle<'a2, C>>> {
+        let renderer = MonoTextStyleBuilder::from(&self.label_properties.renderer)
+            .font(font)
+            .build();
+        let horizontal = self.label_properties.horizontal;
+        let vertical = self.label_properties.vertical;
+
+        self.style(TextBoxStyle {
+            renderer,
+            horizontal,
+            vertical,
+        })
+    }
+}
+
+impl<S, F, C, DT> WidgetRenderer<EgCanvas<DT>> for TextBox<S, TextBoxStyle<F>>
+where
+    S: AsRef<str>,
+    F: TextRenderer<Color = C> + CharacterStyle<Color = C>,
+    C: PixelColor + From<Rgb888>,
+    DT: DrawTarget<Color = C>,
+{
+    fn draw(&self, canvas: &mut EgCanvas<DT>) -> Result<(), DT::Error> {
+        EgTextBox::with_textbox_style(
+            self.text.as_ref(),
+            self.bounds.to_rectangle(),
+            self.label_properties.renderer.clone(),
+            TextBoxStyleBuilder::new()
+                .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
+                .alignment(self.label_properties.horizontal)
+                .vertical_alignment(self.label_properties.vertical)
+                .build(),
+        )
+        .draw(&mut canvas.target)
+        .map(|_| ())
+    }
+}
+
+macro_rules! textbox_for_charset {
+    ($charset:ident, $font:ident) => {
+        pub mod $charset {
+            use embedded_graphics::{
+                mono_font::{$charset, MonoTextStyle},
+                pixelcolor::PixelColor,
+            };
+            use embedded_gui::{geometry::BoundingBox, widgets::text_box::TextBox};
+            use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
+
+            use crate::{themes::Theme, widgets::text_box::TextBoxStyle};
+
+            pub trait TextBoxConstructor<'a, S, C>
+            where
+                S: AsRef<str>,
+                C: PixelColor,
+            {
+                fn new(text: S) -> TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>;
+            }
+
+            impl<'a, 'b, 'c, C, S> TextBoxConstructor<'a, S, C>
+                for TextBox<S, TextBoxStyle<MonoTextStyle<'a, C>>>
+            where
+                S: AsRef<str>,
+                C: PixelColor + Theme,
+            {
+                fn new(text: S) -> Self {
+                    TextBox {
+                        parent_index: 0,
+                        text,
+                        label_properties: TextBoxStyle {
+                            renderer: MonoTextStyle::new(
+                                &$charset::$font,
+                                <C as Theme>::TEXT_COLOR,
+                            ),
+                            horizontal: HorizontalAlignment::Left,
+                            vertical: VerticalAlignment::Top,
+                        },
+                        bounds: BoundingBox::default(),
+                        on_state_changed: |_, _| (),
+                    }
+                }
+            }
+        }
+    };
+
+    ($charset:ident) => {
+        textbox_for_charset!($charset, FONT_6X10);
+    };
+}
+
+textbox_for_charset!(ascii);
+textbox_for_charset!(iso_8859_1);
+textbox_for_charset!(iso_8859_10);
+textbox_for_charset!(iso_8859_13);
+textbox_for_charset!(iso_8859_14);
+textbox_for_charset!(iso_8859_15);
+textbox_for_charset!(iso_8859_16);
+textbox_for_charset!(iso_8859_2);
+textbox_for_charset!(iso_8859_3);
+textbox_for_charset!(iso_8859_4);
+textbox_for_charset!(iso_8859_5);
+textbox_for_charset!(iso_8859_7);
+textbox_for_charset!(iso_8859_9);
+textbox_for_charset!(jis_x0201, FONT_6X13);

--- a/backend-embedded-graphics/src/widgets/text_box/plugin.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/plugin.rs
@@ -121,13 +121,13 @@ impl Cursor {
     }
 }
 
-pub(super) struct EditorInput<const N: usize> {
-    pub text: String<N>,
+pub(super) struct EditorInput<'a, const N: usize> {
+    pub text: &'a mut String<N>,
     pub cursor: Cursor,
 }
 
-impl<const N: usize> EditorInput<N> {
-    pub fn new(text: String<N>) -> Self {
+impl<'a, const N: usize> EditorInput<'a, N> {
+    pub fn new(text: &'a mut String<N>) -> Self {
         Self {
             cursor: Cursor {
                 offset: text.len(),

--- a/backend-embedded-graphics/src/widgets/text_box/plugin.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/plugin.rs
@@ -1,5 +1,3 @@
-use core::ops::Sub;
-
 use az::SaturatingAs;
 use embedded_graphics::{
     draw_target::DrawTarget,
@@ -443,23 +441,21 @@ impl<'a, C: PixelColor> Plugin<'a, C> for EditorPlugin<C> {
                     .contains(&desired_cursor_position) =>
             {
                 let chars_before = desired_cursor_position - self.current_offset;
-                let pos = if chars_before == 0 {
-                    // we want the end of the last character
-                    bounds
-                        .top_left
-                        .sub(Point::new(1, 0))
-                        .component_max(self.top_left)
-                } else {
-                    character_style
-                        .measure_string(
-                            text.unwrap().first_n_chars(chars_before),
-                            bounds.top_left,
-                            Baseline::Top,
-                        )
-                        .bounding_box
-                        .anchor_point(AnchorPoint::TopRight)
-                };
-                self.draw_cursor(draw_target, bounds, pos)?;
+
+                let Point { x: left, y: top } = bounds.top_left;
+
+                let dx = character_style
+                    .measure_string(
+                        text.unwrap_or("").first_n_chars(chars_before),
+                        bounds.top_left,
+                        Baseline::Top,
+                    )
+                    .bounding_box
+                    .size
+                    .width
+                    .min(bounds.size.width) as i32;
+
+                self.draw_cursor(draw_target, bounds, Point::new(left + dx, top))?;
                 self.current_offset = desired_cursor_position;
             }
 

--- a/backend-embedded-graphics/src/widgets/text_box/plugin.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/plugin.rs
@@ -1,0 +1,393 @@
+use core::ops::Sub;
+
+use az::SaturatingAs;
+use embedded_graphics::{
+    draw_target::DrawTarget,
+    geometry::AnchorPoint,
+    prelude::{PixelColor, Point, Primitive},
+    primitives::{Line, PrimitiveStyle, Rectangle},
+    text::{
+        renderer::{CharacterStyle, TextRenderer},
+        Baseline,
+    },
+    Drawable,
+};
+use embedded_text::{plugin::Plugin, Cursor as RenderingCursor, TextBoxProperties};
+use heapless::String;
+
+trait StrExt {
+    fn first_n_chars<'a>(&'a self, n: usize) -> &'a str;
+}
+
+impl StrExt for str {
+    fn first_n_chars<'a>(&'a self, n: usize) -> &'a str {
+        if let Some((i, (idx, _))) = self.char_indices().enumerate().take(n + 1).last() {
+            if i < n as usize {
+                self
+            } else {
+                &self[0..idx]
+            }
+        } else {
+            self
+        }
+    }
+}
+
+pub(super) struct Cursor {
+    /// character offset
+    offset: usize,
+
+    /// cursor position in screen coordinates
+    pos: Point,
+
+    /// current command
+    desired_position: DesiredPosition,
+
+    /// text vertical offset
+    vertical_offset: i32,
+}
+
+impl Cursor {
+    fn plugin<C: PixelColor>(&mut self, color: C) -> EditorPlugin<C> {
+        EditorPlugin {
+            cursor_position: self.pos,
+            current_offset: 0,
+            desired_cursor_position: self.desired_position,
+            color,
+            cursor_drawn: false,
+            vertical_offset: self.vertical_offset,
+            top_left: Point::zero(),
+        }
+    }
+}
+
+pub(super) struct EditorInput<const N: usize> {
+    pub text: String<N>,
+    pub cursor: Cursor,
+}
+
+impl<const N: usize> EditorInput<N> {
+    pub fn new(text: String<N>) -> Self {
+        Self {
+            cursor: Cursor {
+                offset: text.len(),
+                pos: Point::zero(),
+                desired_position: DesiredPosition::EndOfText,
+                vertical_offset: 0,
+            },
+            text,
+        }
+    }
+
+    pub fn insert(&mut self, s: &str) {
+        //self.text.insert_str(self.cursor.offset, s);
+        self.cursor.offset += s.len();
+        self.cursor.desired_position = DesiredPosition::Offset(self.cursor.offset);
+    }
+
+    pub fn delete_before(&mut self) {
+        if self.cursor.offset > 0 {
+            self.cursor.offset -= 1;
+            self.cursor.desired_position = DesiredPosition::Offset(self.cursor.offset);
+            //self.text.remove(self.cursor.offset);
+        }
+    }
+
+    pub fn delete_after(&mut self) {
+        if self.cursor.offset < self.text.chars().count() {
+            //self.text.remove(self.cursor.offset);
+        }
+    }
+
+    pub fn cursor_left(&mut self) {
+        if self.cursor.offset > 0 {
+            self.cursor.desired_position = DesiredPosition::Offset(self.cursor.offset - 1);
+        }
+    }
+
+    pub fn cursor_right(&mut self) {
+        if self.cursor.offset < self.text.len() {
+            self.cursor.desired_position = DesiredPosition::Offset(self.cursor.offset + 1);
+        }
+    }
+
+    pub fn cursor_up(&mut self) {
+        self.cursor.desired_position = DesiredPosition::OneLineUp(
+            self.cursor.desired_position.coordinates_or(self.cursor.pos),
+        );
+    }
+
+    pub fn cursor_down(&mut self) {
+        self.cursor.desired_position = DesiredPosition::OneLineDown(
+            self.cursor.desired_position.coordinates_or(self.cursor.pos),
+        );
+    }
+
+    pub fn move_cursor_to(&mut self, point: Point) {
+        self.cursor.desired_position = DesiredPosition::ScreenCoordinates(point);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DesiredPosition {
+    OneLineUp(Point),
+    OneLineDown(Point),
+    EndOfText,
+    Offset(usize),
+    /// Move the cursor to the desired text space coordinates
+    Coordinates(Point),
+    /// Move the cursor to the desired screen space coordinates
+    ScreenCoordinates(Point),
+}
+
+impl DesiredPosition {
+    fn coordinates_or(&self, fallback: Point) -> Point {
+        match self {
+            DesiredPosition::Coordinates(c) => *c,
+            _ => fallback,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct EditorPlugin<C> {
+    desired_cursor_position: DesiredPosition,
+    cursor_position: Point,
+    current_offset: usize,
+    color: C,
+    cursor_drawn: bool,
+
+    /// text vertical offset
+    vertical_offset: i32,
+    top_left: Point,
+}
+
+impl<C: PixelColor> EditorPlugin<C> {
+    #[track_caller]
+    fn draw_cursor<D>(
+        &mut self,
+        draw_target: &mut D,
+        bounds: Rectangle,
+        pos: Point,
+    ) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
+        let pos = Point::new(pos.x.max(self.top_left.x), pos.y);
+        self.cursor_position = self.to_text_space(pos);
+        self.cursor_drawn = true;
+
+        let style = PrimitiveStyle::with_stroke(self.color, 1);
+        Line::new(
+            pos + Point::new(0, 1),
+            pos + Point::new(0, bounds.size.height as i32 - 1),
+        )
+        .into_styled(style)
+        .draw(draw_target)
+    }
+
+    fn to_text_space(&self, point: Point) -> Point {
+        point - Point::new(0, self.vertical_offset) - self.top_left
+    }
+
+    fn to_screen_space(&self, point: Point) -> Point {
+        point + Point::new(0, self.vertical_offset) + self.top_left
+    }
+
+    fn update_cursor(self, cursor: &mut Cursor) {
+        cursor.pos = self.cursor_position;
+        cursor.offset = self.current_offset;
+        cursor.desired_position = self.desired_cursor_position;
+        cursor.vertical_offset = self.vertical_offset;
+    }
+}
+
+impl<'a, C: PixelColor> Plugin<'a, C> for EditorPlugin<C> {
+    fn on_start_render<S: CharacterStyle + TextRenderer>(
+        &mut self,
+        cursor: &mut RenderingCursor,
+        props: &TextBoxProperties<'_, S>,
+    ) {
+        let line_height = props.char_style.line_height() as i32;
+        self.top_left = props.bounding_box.top_left;
+
+        self.desired_cursor_position = match self.desired_cursor_position {
+            DesiredPosition::OneLineUp(old) => {
+                let newy = old.y - line_height;
+
+                if newy < 0 {
+                    DesiredPosition::Offset(0)
+                } else {
+                    DesiredPosition::Coordinates(Point::new(old.x, newy))
+                }
+            }
+            DesiredPosition::OneLineDown(old) => {
+                let newy = old.y + line_height;
+
+                if newy >= props.text_height {
+                    DesiredPosition::EndOfText
+                } else {
+                    DesiredPosition::Coordinates(Point::new(old.x, newy))
+                }
+            }
+            DesiredPosition::ScreenCoordinates(point) => {
+                let point = self.to_text_space(point);
+
+                if point.y < 0 {
+                    DesiredPosition::Offset(0)
+                } else if point.y >= props.text_height {
+                    DesiredPosition::EndOfText
+                } else {
+                    DesiredPosition::Coordinates(Point::new(
+                        point.x,
+                        point.y.min(props.text_height),
+                    ))
+                }
+            }
+            pos => pos,
+        };
+
+        let cursor_coordinates = self
+            .desired_cursor_position
+            .coordinates_or(self.cursor_position);
+
+        let cursor_coordinates = self.to_screen_space(cursor_coordinates);
+
+        // Modify current offset value by the amount outside of the current window
+        let box_height: i32 = props.bounding_box.size.height.saturating_as();
+        let bounds_min = props.bounding_box.top_left.y;
+        let bounds_max = bounds_min + box_height;
+
+        self.vertical_offset -= if cursor_coordinates.y < bounds_min {
+            cursor_coordinates.y - bounds_min
+        } else if cursor_coordinates.y + line_height > bounds_max {
+            cursor_coordinates.y + line_height - bounds_max
+        } else {
+            0
+        };
+
+        self.vertical_offset = self
+            .vertical_offset
+            .max(box_height - props.text_height)
+            .min(0);
+
+        cursor.y += self.vertical_offset;
+
+        if let DesiredPosition::Coordinates(pos) = self.desired_cursor_position {
+            self.desired_cursor_position =
+                DesiredPosition::ScreenCoordinates(self.to_screen_space(pos));
+        }
+    }
+
+    fn post_render<T, D>(
+        &mut self,
+        draw_target: &mut D,
+        character_style: &T,
+        text: Option<&str>,
+        bounds: Rectangle,
+    ) -> Result<(), D::Error>
+    where
+        T: TextRenderer<Color = C>,
+        D: DrawTarget<Color = T::Color>,
+    {
+        if self.cursor_drawn {
+            return Ok(());
+        }
+
+        // Convert different positions to offset
+        let len = text.unwrap_or_default().chars().count();
+        let desired_cursor_position = match self.desired_cursor_position {
+            DesiredPosition::EndOfText => {
+                // We only want to draw the cursor, so we don't need to do anything
+                // if we are not at the very end of the text
+                if text.is_none() {
+                    Some(self.current_offset)
+                } else {
+                    None
+                }
+            }
+
+            DesiredPosition::ScreenCoordinates(point) => {
+                let same_line = point.y >= bounds.top_left.y
+                    && point.y <= bounds.anchor_point(AnchorPoint::BottomRight).y;
+
+                if same_line {
+                    match text {
+                        Some("\n") | None => {
+                            // end of text, or cursor is positioned before the text begins
+                            Some(self.current_offset)
+                        }
+                        Some(text) if bounds.anchor_point(AnchorPoint::TopRight).x > point.x => {
+                            // Figure out the number of drawn characters, set cursor position
+                            // TODO: this can be simplified by iterating over char_indices
+                            let mut add = len;
+                            let mut anchor_point = bounds.top_left;
+                            for i in 0..len {
+                                let str_before = text.first_n_chars(i).len();
+                                let current_char_offset = text.first_n_chars(i + 1).len();
+                                let char_bounds = character_style
+                                    .measure_string(
+                                        &text[str_before..current_char_offset],
+                                        anchor_point,
+                                        Baseline::Top,
+                                    )
+                                    .bounding_box;
+
+                                let top_right = char_bounds.anchor_point(AnchorPoint::TopRight);
+                                let top_center = char_bounds.anchor_point(AnchorPoint::TopCenter);
+
+                                if top_center.x > point.x {
+                                    add = i;
+                                    break;
+                                }
+                                anchor_point = top_right + Point::new(1, 0);
+                            }
+                            Some(self.current_offset + add)
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            }
+
+            DesiredPosition::Offset(desired_offset) => Some(desired_offset),
+
+            other => unreachable!("{:?} should have been replaced in on_start_render", other),
+        };
+
+        // Draw cursor
+        match desired_cursor_position {
+            Some(desired_cursor_position)
+                if (self.current_offset..self.current_offset + len.max(1))
+                    .contains(&desired_cursor_position) =>
+            {
+                let chars_before = desired_cursor_position - self.current_offset;
+                let pos = if chars_before == 0 {
+                    // we want the end of the last character
+                    bounds
+                        .top_left
+                        .sub(Point::new(1, 0))
+                        .component_max(self.top_left)
+                } else {
+                    character_style
+                        .measure_string(
+                            text.unwrap().first_n_chars(chars_before),
+                            bounds.top_left,
+                            Baseline::Top,
+                        )
+                        .bounding_box
+                        .anchor_point(AnchorPoint::TopRight)
+                };
+                self.draw_cursor(draw_target, bounds, pos)?;
+                self.current_offset = desired_cursor_position;
+            }
+
+            _ => {
+                self.current_offset += len;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -212,7 +212,7 @@ fn main() {
             .add(
                 Spacing::new(
                     FillParent::horizontal(
-                        Label::new(String::<11>::from("0"))
+                        Label::new(String::<11>::new())
                             .font(&FONT_10X20)
                             .bind(&calculator)
                             .on_data_changed(|label, calc| {

--- a/examples/calculator_rgb.rs
+++ b/examples/calculator_rgb.rs
@@ -233,7 +233,7 @@ fn main() {
                 Background::new(
                     Spacing::new(
                         FillParent::horizontal(
-                            Label::new(String::<11>::from("0"))
+                            Label::new(String::<11>::new())
                                 .font(&FONT_10X20)
                                 .bind(&calculator)
                                 .on_data_changed(|label, calc| {

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -15,13 +15,13 @@ use embedded_graphics::{
     draw_target::DrawTarget, pixelcolor::BinaryColor, prelude::Size as EgSize,
 };
 use embedded_graphics_simulator::{
-    sdl2::MouseButton, BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent,
-    Window as SimWindow,
+    sdl2::{Keycode, Mod, MouseButton},
+    BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window as SimWindow,
 };
 use embedded_gui::{
     data::BoundData,
     geometry::Position,
-    input::event::{InputEvent, PointerEvent, ScrollEvent},
+    input::event::{InputEvent, Key, KeyEvent, Modifier, PointerEvent, ScrollEvent},
     prelude::*,
     widgets::{
         label::Label,
@@ -42,6 +42,28 @@ use embedded_gui::{
     },
 };
 use heapless::String;
+
+trait Convert {
+    type Output;
+
+    fn convert(self) -> Self::Output;
+}
+
+impl Convert for Keycode {
+    type Output = Key;
+
+    fn convert(self) -> Self::Output {
+        Key::A
+    }
+}
+
+impl Convert for Mod {
+    type Output = Modifier;
+
+    fn convert(self) -> Self::Output {
+        Modifier::None
+    }
+}
 
 fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
     unsafe {
@@ -93,6 +115,21 @@ fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
                     ScrollEvent::HorizontalScroll(scroll_delta.x * 4)
                 }))
             }
+            SimulatorEvent::KeyDown {
+                keycode, keymod, ..
+            } => Ok(InputEvent::KeyEvent(KeyEvent::KeyDown(
+                keycode.convert(),
+                keymod.convert(),
+                0,
+            ))),
+
+            SimulatorEvent::KeyUp {
+                keycode, keymod, ..
+            } => Ok(InputEvent::KeyEvent(KeyEvent::KeyUp(
+                keycode.convert(),
+                keymod.convert(),
+            ))),
+
             SimulatorEvent::Quit => Err(true),
             _ => Err(false),
         }

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -212,6 +212,8 @@ fn main() {
     let toggle = BoundData::new(false, |_| ());
     let checkables = BoundData::new((&radio, &checkbox, &toggle), |_| ());
 
+    let text_reset = BoundData::new(false, |_| ());
+
     let slider1_data = BoundData::new(0, |_| ());
     let slider2_data = BoundData::new(0, |_| ());
     let sliders = BoundData::new((&slider1_data, &slider2_data), |_| ());
@@ -265,11 +267,27 @@ fn main() {
         )
         .weight(1)
         .add(
-            Column::new().add(Label::new("TextBox")).add(
-            Border::new(FillParent::both(TextBox::new(
-                String::<100>::from("A TextBox with editable content. Click me and start typing!"),
-            ))
-            .align_vertical(Top)))
+            Column::new().add(Label::new("TextBox"))
+            .add(
+                Border::new(
+                    TextBox::new(
+                        String::<100>::from("A TextBox with editable content. Click me and start typing!"),
+                    )
+                    .bind(&text_reset)
+                    .on_data_changed(|text_box, reset| {
+                        if *reset {
+                            text_box.set_text("");
+                        }
+                    })
+                    .on_text_changed(|reset, _text| *reset = false)
+                )
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("Clear")
+                .bind(&text_reset)
+                .on_clicked(|reset| *reset = true)
+            )
         )
         .weight(1);
 

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -29,12 +29,7 @@ use embedded_gui::{
             frame::Frame,
             linear::{column::Column, row::Row},
         },
-        primitives::{
-            border::Border,
-            fill::{FillParent, Top},
-            spacing::Spacing,
-            visibility::Visibility,
-        },
+        primitives::{border::Border, fill::FillParent, spacing::Spacing, visibility::Visibility},
         scroll::Scroll,
         slider::ScrollbarConnector,
         text_block::TextBlock,
@@ -255,39 +250,36 @@ fn main() {
     let text_block_page = Row::new()
         .spacing(1)
         .add(
-            Column::new().add(Label::new("TextBlock")).add(
-            Border::new(FillParent::both(
+            Column::new().add(Label::new("TextBlock")).add(Border::new(
                 TextBlock::new(
                     "Some \x1b[4mstylish\x1b[24m multiline text that expands the widget vertically",
                 )
                 .horizontal_alignment(HorizontalAlignment::Center)
                 .vertical_alignment(VerticalAlignment::Middle),
-            )
-            .align_vertical(Top)))
+            )),
         )
         .weight(1)
         .add(
-            Column::new().add(Label::new("TextBox"))
-            .add(
-                Border::new(
-                    TextBox::new(
-                        String::<100>::from("A TextBox with editable content. Click me and start typing!"),
-                    )
+            Column::new()
+                .add(Label::new("TextBox"))
+                .add(Border::new(
+                    TextBox::new(String::<100>::from(
+                        "A TextBox with editable content. Click me and start typing!",
+                    ))
                     .bind(&text_reset)
                     .on_data_changed(|text_box, reset| {
                         if *reset {
                             text_box.set_text("");
                         }
                     })
-                    .on_text_changed(|reset, _text| *reset = false)
-                )
-            )
-            .weight(1)
-            .add(
-                DefaultTheme::primary_button("Clear")
-                .bind(&text_reset)
-                .on_clicked(|reset| *reset = true)
-            )
+                    .on_text_changed(|reset, _text| *reset = false),
+                ))
+                .weight(1)
+                .add(
+                    DefaultTheme::primary_button("Clear")
+                        .bind(&text_reset)
+                        .on_clicked(|reset| *reset = true),
+                ),
         )
         .weight(1);
 

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -2,10 +2,10 @@ use std::{fmt::Write, thread, time::Duration};
 
 use backend_embedded_graphics::{
     themes::{default::DefaultTheme, Theme},
-    widgets::textbox::{ascii::TextBoxConstructor, TextBoxStyling},
+    widgets::text_block::{ascii::TextBlockConstructor, TextBlockStyling},
     widgets::{
         label::ascii::LabelConstructor,
-        textbox::{HorizontalAlignment, VerticalAlignment},
+        text_block::{HorizontalAlignment, VerticalAlignment},
     },
     EgCanvas,
 };
@@ -30,7 +30,7 @@ use embedded_gui::{
         primitives::{border::Border, fill::FillParent, spacing::Spacing, visibility::Visibility},
         scroll::Scroll,
         slider::ScrollbarConnector,
-        textbox::TextBox,
+        text_block::TextBlock,
     },
 };
 use heapless::String;
@@ -119,7 +119,7 @@ fn main() {
     let tabs = Row::new()
         .spacing(1)
         .add(
-            DefaultTheme::toggle_button("Textbox")
+            DefaultTheme::toggle_button("Text block")
                 .disallow_manual_uncheck()
                 .bind(&page)
                 .on_selected_changed(|_, page| *page = Page::Textbox)
@@ -148,7 +148,7 @@ fn main() {
         );
 
     let textbox_page = Border::new(FillParent::both(
-        TextBox::new(
+        TextBlock::new(
             "Some \x1b[4mstylish\x1b[24m multiline text that expands the widget vertically",
         )
         .horizontal_alignment(HorizontalAlignment::Center)

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -50,10 +50,60 @@ trait Convert {
 }
 
 impl Convert for Keycode {
-    type Output = Key;
+    type Output = Option<Key>;
 
     fn convert(self) -> Self::Output {
-        Key::A
+        match self {
+            Keycode::Backspace => Some(Key::Backspace),
+            Keycode::Tab => Some(Key::Tab),
+            Keycode::Return => Some(Key::Enter),
+            Keycode::Space => Some(Key::Space),
+            Keycode::KpComma | Keycode::Comma => Some(Key::Comma),
+            Keycode::KpMinus | Keycode::Minus => Some(Key::Minus),
+            Keycode::KpPeriod | Keycode::Period => Some(Key::Period),
+            Keycode::Kp1 | Keycode::Num0 => Some(Key::N0),
+            Keycode::Kp2 | Keycode::Num1 => Some(Key::N1),
+            Keycode::Kp3 | Keycode::Num2 => Some(Key::N2),
+            Keycode::Kp4 | Keycode::Num3 => Some(Key::N3),
+            Keycode::Kp5 | Keycode::Num4 => Some(Key::N4),
+            Keycode::Kp6 | Keycode::Num5 => Some(Key::N5),
+            Keycode::Kp7 | Keycode::Num6 => Some(Key::N6),
+            Keycode::Kp8 | Keycode::Num7 => Some(Key::N7),
+            Keycode::Kp9 | Keycode::Num8 => Some(Key::N8),
+            Keycode::Kp0 | Keycode::Num9 => Some(Key::N9),
+            Keycode::A => Some(Key::A),
+            Keycode::B => Some(Key::B),
+            Keycode::C => Some(Key::C),
+            Keycode::D => Some(Key::D),
+            Keycode::E => Some(Key::E),
+            Keycode::F => Some(Key::F),
+            Keycode::G => Some(Key::G),
+            Keycode::H => Some(Key::H),
+            Keycode::I => Some(Key::I),
+            Keycode::J => Some(Key::J),
+            Keycode::K => Some(Key::K),
+            Keycode::L => Some(Key::L),
+            Keycode::M => Some(Key::M),
+            Keycode::N => Some(Key::N),
+            Keycode::O => Some(Key::O),
+            Keycode::P => Some(Key::P),
+            Keycode::Q => Some(Key::Q),
+            Keycode::R => Some(Key::R),
+            Keycode::S => Some(Key::S),
+            Keycode::T => Some(Key::T),
+            Keycode::U => Some(Key::U),
+            Keycode::V => Some(Key::V),
+            Keycode::W => Some(Key::W),
+            Keycode::X => Some(Key::X),
+            Keycode::Y => Some(Key::Y),
+            Keycode::Z => Some(Key::Z),
+            Keycode::Delete => Some(Key::Del),
+            Keycode::Right => Some(Key::ArrowRight),
+            Keycode::Left => Some(Key::ArrowLeft),
+            Keycode::Down => Some(Key::ArrowDown),
+            Keycode::Up => Some(Key::ArrowUp),
+            _ => None,
+        }
     }
 }
 
@@ -61,7 +111,15 @@ impl Convert for Mod {
     type Output = Modifier;
 
     fn convert(self) -> Self::Output {
-        Modifier::None
+        if self.contains(Mod::RALTMOD) {
+            Modifier::Alt
+        } else if self.intersects(Mod::LSHIFTMOD | Mod::RSHIFTMOD) {
+            Modifier::Shift
+        } else if self.contains(Mod::CAPSMOD) {
+            Modifier::Shift
+        } else {
+            Modifier::None
+        }
     }
 }
 
@@ -118,7 +176,7 @@ fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
             SimulatorEvent::KeyDown {
                 keycode, keymod, ..
             } => Ok(InputEvent::KeyEvent(KeyEvent::KeyDown(
-                keycode.convert(),
+                keycode.convert().ok_or(false)?,
                 keymod.convert(),
                 0,
             ))),
@@ -126,7 +184,7 @@ fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
             SimulatorEvent::KeyUp {
                 keycode, keymod, ..
             } => Ok(InputEvent::KeyEvent(KeyEvent::KeyUp(
-                keycode.convert(),
+                keycode.convert().ok_or(false)?,
                 keymod.convert(),
             ))),
 
@@ -209,7 +267,7 @@ fn main() {
         .add(
             Column::new().add(Label::new("TextBox")).add(
             Border::new(FillParent::both(TextBox::new(
-                "A TextBox with editable content. Click me and start typing!",
+                String::<100>::from("A TextBox with editable content. Click me and start typing!"),
             ))
             .align_vertical(Top)))
         )

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -209,7 +209,7 @@ fn main() {
     let toggle = BoundData::new(false, |_| ());
     let checkables = BoundData::new((&radio, &checkbox, &toggle), |_| ());
 
-    let text_reset = BoundData::new(false, |_| ());
+    let text_reset = BoundData::new((false, false), |_| ());
 
     let slider1_data = BoundData::new(0, |_| ());
     let slider2_data = BoundData::new(0, |_| ());
@@ -269,14 +269,18 @@ fn main() {
             .add(
                 Border::new(
                     TextBox::new(
-                        String::<100>::from("A TextBox with editable content. Click me and start typing!"))
+                        String::<100>::from("A TextBox with editable content. Click me and start typing!")
+                    )
                     .bind(&text_reset)
-                    .on_data_changed(|text_box, reset| {
+                    .on_data_changed(|text_box, (reset, _empty)| {
                         if *reset {
-                            text_box.set_text("");
+                            text_box.text.clear();
                         }
                     })
-                    .on_text_changed(|reset, _text| *reset = false)
+                    .on_text_changed(|(reset, empty), text| {
+                        *reset = false;
+                        *empty = text == "";
+                    })
                 )
                 .border_color(Rgb888::CSS_LIGHT_GRAY)
             )
@@ -284,7 +288,14 @@ fn main() {
             .add(
                 DefaultTheme::primary_button("Clear")
                 .bind(&text_reset)
-                .on_clicked(|reset| *reset = true)
+                .on_clicked(|(reset, empty)| {
+                    *reset = true;
+                    // Resetting means the text box will be empty
+                    *empty = true;
+                })
+                .on_data_changed(|button, (_, empty)| {
+                    button.set_active(!*empty);
+                })
             )
         )
         .weight(1);

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -268,7 +268,8 @@ fn main() {
             .add(Label::new("TextBox"))
             .add(
                 Border::new(
-                    TextBox::new(String::<100>::from("A TextBox with editable content. Click me and start typing!"))
+                    TextBox::new(
+                        String::<100>::from("A TextBox with editable content. Click me and start typing!"))
                     .bind(&text_reset)
                     .on_data_changed(|text_box, reset| {
                         if *reset {

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -278,9 +278,10 @@ fn main() {
                     .bind(&text_reset)
                     .on_data_changed(|text_box, reset| {
                         if *reset {
-                            text_box.text = String::<100>::new();
+                            text_box.set_text("");
                         }
                     })
+                    .on_text_changed(|reset, _text| *reset = false)
                 )
                 .border_color(Rgb888::CSS_LIGHT_GRAY)
             )

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -31,12 +31,7 @@ use embedded_gui::{
             frame::Frame,
             linear::{column::Column, row::Row},
         },
-        primitives::{
-            border::Border,
-            fill::{FillParent, Top},
-            spacing::Spacing,
-            visibility::Visibility,
-        },
+        primitives::{border::Border, fill::FillParent, spacing::Spacing, visibility::Visibility},
         scroll::Scroll,
         slider::ScrollbarConnector,
         text_block::TextBlock,
@@ -258,14 +253,13 @@ fn main() {
         .spacing(1)
         .add(
             Column::new().add(Label::new("TextBlock")).add(
-            Border::new(FillParent::both(
+            Border::new(
                 TextBlock::new(
                     "Some \x1b[4mstylish\x1b[24m multiline text that expands the widget vertically",
                 )
                 .horizontal_alignment(HorizontalAlignment::Center)
                 .vertical_alignment(VerticalAlignment::Middle)
             )
-            .align_vertical(Top))
             .border_color(Rgb888::CSS_LIGHT_GRAY))
         )
         .weight(1)

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -17,12 +17,13 @@ use embedded_graphics::{
     prelude::{Size as EgSize, WebColors},
 };
 use embedded_graphics_simulator::{
-    sdl2::MouseButton, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window as SimWindow,
+    sdl2::{Keycode, Mod, MouseButton},
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window as SimWindow,
 };
 use embedded_gui::{
     data::BoundData,
     geometry::Position,
-    input::event::{InputEvent, PointerEvent, ScrollEvent},
+    input::event::{InputEvent, Key, KeyEvent, Modifier, PointerEvent, ScrollEvent},
     prelude::*,
     widgets::{
         label::Label,
@@ -43,6 +44,28 @@ use embedded_gui::{
     },
 };
 use heapless::String;
+
+trait Convert {
+    type Output;
+
+    fn convert(self) -> Self::Output;
+}
+
+impl Convert for Keycode {
+    type Output = Key;
+
+    fn convert(self) -> Self::Output {
+        Key::A
+    }
+}
+
+impl Convert for Mod {
+    type Output = Modifier;
+
+    fn convert(self) -> Self::Output {
+        Modifier::None
+    }
+}
 
 fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
     unsafe {
@@ -94,6 +117,21 @@ fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
                     ScrollEvent::HorizontalScroll(scroll_delta.x * 4)
                 }))
             }
+            SimulatorEvent::KeyDown {
+                keycode, keymod, ..
+            } => Ok(InputEvent::KeyEvent(KeyEvent::KeyDown(
+                keycode.convert(),
+                keymod.convert(),
+                0,
+            ))),
+
+            SimulatorEvent::KeyUp {
+                keycode, keymod, ..
+            } => Ok(InputEvent::KeyEvent(KeyEvent::KeyUp(
+                keycode.convert(),
+                keymod.convert(),
+            ))),
+
             SimulatorEvent::Quit => Err(true),
             _ => Err(false),
         }

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -4,8 +4,8 @@ use backend_embedded_graphics::{
     themes::{default::DefaultTheme, Theme},
     widgets::{
         label::ascii::LabelConstructor,
-        textbox::{
-            ascii::TextBoxConstructor, HorizontalAlignment, TextBoxStyling, VerticalAlignment,
+        text_block::{
+            ascii::TextBlockConstructor, HorizontalAlignment, TextBlockStyling, VerticalAlignment,
         },
     },
     EgCanvas,
@@ -32,7 +32,7 @@ use embedded_gui::{
         primitives::{border::Border, fill::FillParent, spacing::Spacing, visibility::Visibility},
         scroll::Scroll,
         slider::ScrollbarConnector,
-        textbox::TextBox,
+        text_block::TextBlock,
     },
 };
 use heapless::String;
@@ -121,7 +121,7 @@ fn main() {
     let tabs = Row::new()
         .spacing(1)
         .add(
-            DefaultTheme::toggle_button("Textbox")
+            DefaultTheme::toggle_button("Text block")
                 .disallow_manual_uncheck()
                 .bind(&page)
                 .on_selected_changed(|_, page| *page = Page::Textbox)
@@ -150,7 +150,7 @@ fn main() {
         );
 
     let textbox_page = Border::new(FillParent::both(
-        TextBox::new(
+        TextBlock::new(
             "Some \x1b[4mstylish\x1b[24m multiline text that expands the widget vertically",
         )
         .horizontal_alignment(HorizontalAlignment::Center)

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -52,10 +52,60 @@ trait Convert {
 }
 
 impl Convert for Keycode {
-    type Output = Key;
+    type Output = Option<Key>;
 
     fn convert(self) -> Self::Output {
-        Key::A
+        match self {
+            Keycode::Backspace => Some(Key::Backspace),
+            Keycode::Tab => Some(Key::Tab),
+            Keycode::Return => Some(Key::Enter),
+            Keycode::Space => Some(Key::Space),
+            Keycode::KpComma | Keycode::Comma => Some(Key::Comma),
+            Keycode::KpMinus | Keycode::Minus => Some(Key::Minus),
+            Keycode::KpPeriod | Keycode::Period => Some(Key::Period),
+            Keycode::Kp1 | Keycode::Num0 => Some(Key::N0),
+            Keycode::Kp2 | Keycode::Num1 => Some(Key::N1),
+            Keycode::Kp3 | Keycode::Num2 => Some(Key::N2),
+            Keycode::Kp4 | Keycode::Num3 => Some(Key::N3),
+            Keycode::Kp5 | Keycode::Num4 => Some(Key::N4),
+            Keycode::Kp6 | Keycode::Num5 => Some(Key::N5),
+            Keycode::Kp7 | Keycode::Num6 => Some(Key::N6),
+            Keycode::Kp8 | Keycode::Num7 => Some(Key::N7),
+            Keycode::Kp9 | Keycode::Num8 => Some(Key::N8),
+            Keycode::Kp0 | Keycode::Num9 => Some(Key::N9),
+            Keycode::A => Some(Key::A),
+            Keycode::B => Some(Key::B),
+            Keycode::C => Some(Key::C),
+            Keycode::D => Some(Key::D),
+            Keycode::E => Some(Key::E),
+            Keycode::F => Some(Key::F),
+            Keycode::G => Some(Key::G),
+            Keycode::H => Some(Key::H),
+            Keycode::I => Some(Key::I),
+            Keycode::J => Some(Key::J),
+            Keycode::K => Some(Key::K),
+            Keycode::L => Some(Key::L),
+            Keycode::M => Some(Key::M),
+            Keycode::N => Some(Key::N),
+            Keycode::O => Some(Key::O),
+            Keycode::P => Some(Key::P),
+            Keycode::Q => Some(Key::Q),
+            Keycode::R => Some(Key::R),
+            Keycode::S => Some(Key::S),
+            Keycode::T => Some(Key::T),
+            Keycode::U => Some(Key::U),
+            Keycode::V => Some(Key::V),
+            Keycode::W => Some(Key::W),
+            Keycode::X => Some(Key::X),
+            Keycode::Y => Some(Key::Y),
+            Keycode::Z => Some(Key::Z),
+            Keycode::Delete => Some(Key::Del),
+            Keycode::Right => Some(Key::ArrowRight),
+            Keycode::Left => Some(Key::ArrowLeft),
+            Keycode::Down => Some(Key::ArrowDown),
+            Keycode::Up => Some(Key::ArrowUp),
+            _ => None,
+        }
     }
 }
 
@@ -63,7 +113,15 @@ impl Convert for Mod {
     type Output = Modifier;
 
     fn convert(self) -> Self::Output {
-        Modifier::None
+        if self.contains(Mod::RALTMOD) {
+            Modifier::Alt
+        } else if self.intersects(Mod::LSHIFTMOD | Mod::RSHIFTMOD) {
+            Modifier::Shift
+        } else if self.contains(Mod::CAPSMOD) {
+            Modifier::Shift
+        } else {
+            Modifier::None
+        }
     }
 }
 
@@ -120,7 +178,7 @@ fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
             SimulatorEvent::KeyDown {
                 keycode, keymod, ..
             } => Ok(InputEvent::KeyEvent(KeyEvent::KeyDown(
-                keycode.convert(),
+                keycode.convert().ok_or(false)?,
                 keymod.convert(),
                 0,
             ))),
@@ -128,7 +186,7 @@ fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
             SimulatorEvent::KeyUp {
                 keycode, keymod, ..
             } => Ok(InputEvent::KeyEvent(KeyEvent::KeyUp(
-                keycode.convert(),
+                keycode.convert().ok_or(false)?,
                 keymod.convert(),
             ))),
 

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -165,7 +165,7 @@ fn main() {
                     "Some \x1b[4mstylish\x1b[24m multiline text that expands the widget vertically",
                 )
                 .horizontal_alignment(HorizontalAlignment::Center)
-                .vertical_alignment(VerticalAlignment::Middle),
+                .vertical_alignment(VerticalAlignment::Middle)
             )
             .align_vertical(Top))
             .border_color(Rgb888::CSS_LIGHT_GRAY))

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -214,6 +214,8 @@ fn main() {
     let toggle = BoundData::new(false, |_| ());
     let checkables = BoundData::new((&radio, &checkbox, &toggle), |_| ());
 
+    let text_reset = BoundData::new(false, |_| ());
+
     let slider1_data = BoundData::new(0, |_| ());
     let slider2_data = BoundData::new(0, |_| ());
     let sliders = BoundData::new((&slider1_data, &slider2_data), |_| ());
@@ -268,12 +270,26 @@ fn main() {
         )
         .weight(1)
         .add(
-            Column::new().add(Label::new("TextBox")).add(
-            Border::new(FillParent::both(TextBox::new(
-                String::<100>::from("A TextBox with editable content. Click me and start typing!"),
-            ))
-            .align_vertical(Top))
-            .border_color(Rgb888::CSS_LIGHT_GRAY))
+            Column::new()
+            .add(Label::new("TextBox"))
+            .add(
+                Border::new(
+                    TextBox::new(String::<100>::from("A TextBox with editable content. Click me and start typing!"))
+                    .bind(&text_reset)
+                    .on_data_changed(|text_box, reset| {
+                        if *reset {
+                            text_box.text = String::<100>::new();
+                        }
+                    })
+                )
+                .border_color(Rgb888::CSS_LIGHT_GRAY)
+            )
+            .weight(1)
+            .add(
+                DefaultTheme::primary_button("Clear")
+                .bind(&text_reset)
+                .on_clicked(|reset| *reset = true)
+            )
         )
         .weight(1);
 

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -212,7 +212,7 @@ fn main() {
         .add(
             Column::new().add(Label::new("TextBox")).add(
             Border::new(FillParent::both(TextBox::new(
-                "A TextBox with editable content. Click me and start typing!",
+                String::<100>::from("A TextBox with editable content. Click me and start typing!"),
             ))
             .align_vertical(Top))
             .border_color(Rgb888::CSS_LIGHT_GRAY))

--- a/src/input/event.rs
+++ b/src/input/event.rs
@@ -46,11 +46,11 @@ pub enum Key {
     ArrowRight,
     ArrowDown,
     ArrowLeft,
-    Ctrl,
-    Alt,
-    Shift,
     Del,
     Tab,
+    Comma,
+    Period,
+    Minus,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -62,6 +62,67 @@ pub enum Modifier {
     Ctrl,
     CtrlAlt,
     CtrlShift,
+}
+
+pub trait ToStr {
+    fn to_str(&self) -> Option<&str>;
+}
+
+impl ToStr for (Key, Modifier) {
+    fn to_str(&self) -> Option<&str> {
+        let options = match self.0 {
+            Key::A => Some(("a", "A", "A", "ä")),
+            Key::B => Some(("b", "B", "B", "{")),
+            Key::C => Some(("c", "C", "C", "&")),
+            Key::D => Some(("d", "D", "D", "Đ")),
+            Key::E => Some(("e", "E", "E", "Ä")),
+            Key::F => Some(("f", "F", "F", "[")),
+            Key::G => Some(("g", "G", "G", "]")),
+            Key::H => Some(("h", "H", "H", "")),
+            Key::I => Some(("i", "I", "I", "Í")),
+            Key::J => Some(("j", "J", "J", "í")),
+            Key::K => Some(("k", "K", "K", "ł")),
+            Key::L => Some(("l", "L", "L", "Ł")),
+            Key::M => Some(("m", "M", "M", "<")),
+            Key::N => Some(("n", "N", "N", "}")),
+            Key::O => Some(("o", "O", "O", "")),
+            Key::P => Some(("p", "P", "P", "")),
+            Key::Q => Some(("q", "Q", "Q", "\\")),
+            Key::R => Some(("r", "R", "R", "")),
+            Key::S => Some(("s", "S", "S", "đ")),
+            Key::T => Some(("t", "T", "T", "")),
+            Key::U => Some(("u", "U", "U", "€")),
+            Key::V => Some(("v", "V", "V", "@")),
+            Key::W => Some(("w", "W", "W", "|")),
+            Key::X => Some(("x", "X", "X", "#")),
+            Key::Y => Some(("y", "Y", "Y", ">")),
+            Key::Z => Some(("z", "Z", "Z", "")),
+            Key::N0 => Some(("0", "§", "0", "")),
+            Key::N1 => Some(("1", "'", "1", "~")),
+            Key::N2 => Some(("2", "\"", "2", "ˇ")),
+            Key::N3 => Some(("3", "+", "3", "^")),
+            Key::N4 => Some(("4", "!", "4", "˘")),
+            Key::N5 => Some(("5", "%", "5", "°")),
+            Key::N6 => Some(("6", "/", "6", "˛")),
+            Key::N7 => Some(("7", "=", "7", "`")),
+            Key::N8 => Some(("8", "(", "8", "˙")),
+            Key::N9 => Some(("9", ")", "9", "´")),
+            Key::Space => Some((" ", " ", " ", " ")),
+            Key::Comma => Some((",", "?", ",", " ")),
+            Key::Period => Some((".", ":", ".", ">")),
+            Key::Minus => Some(("-", "_", "-", "*")),
+            Key::Enter => Some(("\n", "\n", "\n", "\n")),
+            Key::Tab => Some(("\t", "\t", "\t", "\t")),
+            _ => None,
+        };
+
+        options.and_then(|choices| match self.1 {
+            Modifier::None => Some(choices.0),
+            Modifier::Shift => Some(choices.1),
+            Modifier::Alt | Modifier::CtrlAlt => Some(choices.3),
+            Modifier::AltShift | Modifier::Ctrl | Modifier::CtrlShift => None,
+        })
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+//#![no_std]
 
 pub mod data;
 pub mod geometry;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -18,13 +18,13 @@ macro_rules! state_group {
     })+) => {
         $(
             pub struct $group;
-            impl StateGroup for $group {
+            impl $crate::state::StateGroup for $group {
                 const MASK: u32 = $mask;
             }
 
             $(
                 pub struct $state;
-                impl State for $state {
+                impl $crate::state::State for $state {
                     type Group = $group;
 
                     const VALUE: u32 = $value;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,5 +1,5 @@
 //! Visual state container.
-mod selection;
+pub mod selection;
 
 pub trait StateGroup {
     const MASK: u32;

--- a/src/state/selection.rs
+++ b/src/state/selection.rs
@@ -1,11 +1,6 @@
 //! Focused state.
 
-use crate::{
-    state::{State, StateGroup},
-    state_group,
-};
-
-state_group! {
+crate::state_group! {
     [SelectionStateGroup: 0x8000_0000] = {
         Unselected = 0,
         Selected = 0x8000_0000,

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -4,7 +4,7 @@ use crate::{
         controller::InputContext,
         event::{InputEvent, PointerEvent},
     },
-    state::{State, StateGroup, WidgetState},
+    state::{State, WidgetState},
     state_group,
     widgets::{utils::decorator::WidgetDecorator, Widget, WidgetDataHolder},
     Canvas, WidgetRenderer,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -13,6 +13,7 @@ pub mod primitives;
 pub mod scroll;
 pub mod slider;
 pub mod text_block;
+pub mod text_box;
 pub mod toggle;
 pub mod utils;
 pub mod wrapper;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -12,7 +12,7 @@ pub mod layouts;
 pub mod primitives;
 pub mod scroll;
 pub mod slider;
-pub mod textbox;
+pub mod text_block;
 pub mod toggle;
 pub mod utils;
 pub mod wrapper;

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -9,7 +9,7 @@ use crate::{
         controller::InputContext,
         event::{InputEvent, PointerEvent, ScrollEvent},
     },
-    state::{State, StateGroup, WidgetState},
+    state::{State, WidgetState},
     state_group,
     widgets::{Widget, WidgetDataHolder},
 };

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -14,7 +14,7 @@ use crate::{
         controller::InputContext,
         event::{InputEvent, PointerEvent, ScrollEvent},
     },
-    state::{State, StateGroup, WidgetState},
+    state::{State, WidgetState},
     state_group,
     widgets::{
         scroll::{ScrollData, ScrollDirection, ScrollFields},

--- a/src/widgets/text_block.rs
+++ b/src/widgets/text_block.rs
@@ -4,11 +4,11 @@ use crate::{
     widgets::{wrapper::WrapperBindable, Widget},
 };
 
-pub trait TextBoxProperties {
+pub trait TextBlockProperties {
     fn measure_text(&self, text: &str, spec: MeasureSpec) -> MeasuredSize;
 }
 
-pub struct TextBox<S, P> {
+pub struct TextBlock<S, P> {
     pub text: S,
     pub label_properties: P,
     pub bounds: BoundingBox,
@@ -16,10 +16,10 @@ pub struct TextBox<S, P> {
     pub on_state_changed: fn(&mut Self, WidgetState),
 }
 
-impl<S, P> TextBox<S, P>
+impl<S, P> TextBlock<S, P>
 where
     S: AsRef<str>,
-    P: TextBoxProperties,
+    P: TextBlockProperties,
 {
     pub fn on_state_changed(mut self, callback: fn(&mut Self, WidgetState)) -> Self {
         self.on_state_changed = callback;
@@ -27,10 +27,10 @@ where
     }
 }
 
-impl<S, P> Widget for TextBox<S, P>
+impl<S, P> Widget for TextBlock<S, P>
 where
     S: AsRef<str>,
-    P: TextBoxProperties,
+    P: TextBlockProperties,
 {
     fn bounding_box(&self) -> BoundingBox {
         self.bounds
@@ -68,9 +68,9 @@ where
     }
 }
 
-impl<S, P> WrapperBindable for TextBox<S, P>
+impl<S, P> WrapperBindable for TextBlock<S, P>
 where
     S: AsRef<str>,
-    P: TextBoxProperties,
+    P: TextBlockProperties,
 {
 }

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -11,22 +11,22 @@ use crate::{
     state_group,
     widgets::{wrapper::WrapperBindable, Widget},
 };
+use heapless::String;
 
 pub trait TextBoxProperties {
     fn measure_text(&self, text: &str, spec: MeasureSpec) -> MeasuredSize;
 }
 
-pub struct TextBox<S, P> {
-    pub text: S,
+pub struct TextBox<P, const N: usize> {
+    pub text: String<N>,
     pub label_properties: P,
     pub bounds: BoundingBox,
     pub parent_index: usize,
     pub state: WidgetState,
 }
 
-impl<S, P> TextBox<S, P>
+impl<P, const N: usize> TextBox<P, N>
 where
-    S: AsRef<str>,
     P: TextBoxProperties,
 {
     fn change_state(&mut self, state: impl State) -> &mut Self {
@@ -51,16 +51,15 @@ state_group! {
     }
 }
 
-impl TextBox<(), ()> {
+impl TextBox<(), 0> {
     pub const STATE_INACTIVE: Inactive = Inactive;
     pub const STATE_ACTIVE: Active = Active;
     pub const STATE_SELECTED: Selected = Selected;
     pub const STATE_UNSELECTED: Unselected = Unselected;
 }
 
-impl<S, P> Widget for TextBox<S, P>
+impl<P, const N: usize> Widget for TextBox<P, N>
 where
-    S: AsRef<str>,
     P: TextBoxProperties,
 {
     fn bounding_box(&self) -> BoundingBox {
@@ -173,9 +172,4 @@ where
     }
 }
 
-impl<S, P> WrapperBindable for TextBox<S, P>
-where
-    S: AsRef<str>,
-    P: TextBoxProperties,
-{
-}
+impl<P, const N: usize> WrapperBindable for TextBox<P, N> where P: TextBoxProperties {}

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -112,11 +112,11 @@ where
             }
 
             InputEvent::PointerEvent(position, PointerEvent::Down) => {
-                if self.bounding_box().contains(position)
-                    || self.state.has_state(TextBox::STATE_SELECTED)
-                {
+                if self.bounding_box().contains(position) {
                     Some(0)
                 } else {
+                    // Allow a potentially clicked widget to handle the event.
+                    self.change_state(TextBox::STATE_UNSELECTED);
                     None
                 }
             }
@@ -151,12 +151,8 @@ where
             InputEvent::PointerEvent(pos, pe) => match pe {
                 // TODO: later we might want to handle drag and up to support text selection
                 PointerEvent::Down => {
-                    if self.bounding_box().contains(pos) {
-                        self.change_state(TextBox::STATE_SELECTED);
-                        self.label_properties.handle_cursor_down(pos);
-                    } else {
-                        self.change_state(TextBox::STATE_UNSELECTED);
-                    }
+                    self.change_state(TextBox::STATE_SELECTED);
+                    self.label_properties.handle_cursor_down(pos);
 
                     true
                 }

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -1,0 +1,76 @@
+use crate::{
+    geometry::{measurement::MeasureSpec, BoundingBox, MeasuredSize},
+    state::WidgetState,
+    widgets::{wrapper::WrapperBindable, Widget},
+};
+
+pub trait TextBoxProperties {
+    fn measure_text(&self, text: &str, spec: MeasureSpec) -> MeasuredSize;
+}
+
+pub struct TextBox<S, P> {
+    pub text: S,
+    pub label_properties: P,
+    pub bounds: BoundingBox,
+    pub parent_index: usize,
+    pub on_state_changed: fn(&mut Self, WidgetState),
+}
+
+impl<S, P> TextBox<S, P>
+where
+    S: AsRef<str>,
+    P: TextBoxProperties,
+{
+    pub fn on_state_changed(mut self, callback: fn(&mut Self, WidgetState)) -> Self {
+        self.on_state_changed = callback;
+        self
+    }
+}
+
+impl<S, P> Widget for TextBox<S, P>
+where
+    S: AsRef<str>,
+    P: TextBoxProperties,
+{
+    fn bounding_box(&self) -> BoundingBox {
+        self.bounds
+    }
+
+    fn bounding_box_mut(&mut self) -> &mut BoundingBox {
+        &mut self.bounds
+    }
+
+    fn parent_index(&self) -> usize {
+        self.parent_index
+    }
+
+    fn set_parent(&mut self, index: usize) {
+        self.parent_index = index;
+    }
+
+    fn measure(&mut self, measure_spec: MeasureSpec) {
+        let size = self
+            .label_properties
+            .measure_text(self.text.as_ref(), measure_spec);
+
+        let width = measure_spec.width.apply_to_measured(size.width);
+        let height = measure_spec.height.apply_to_measured(size.height);
+
+        self.bounds.size = MeasuredSize { width, height };
+    }
+
+    fn on_state_changed(&mut self, state: WidgetState) {
+        (self.on_state_changed)(self, state);
+    }
+
+    fn is_selectable(&self) -> bool {
+        false
+    }
+}
+
+impl<S, P> WrapperBindable for TextBox<S, P>
+where
+    S: AsRef<str>,
+    P: TextBoxProperties,
+{
+}

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -1,6 +1,9 @@
 use crate::{
     geometry::{measurement::MeasureSpec, BoundingBox, MeasuredSize},
-    state::WidgetState,
+    state::{
+        selection::{Selected, Unselected},
+        WidgetState,
+    },
     widgets::{wrapper::WrapperBindable, Widget},
 };
 
@@ -14,6 +17,7 @@ pub struct TextBox<S, P> {
     pub bounds: BoundingBox,
     pub parent_index: usize,
     pub on_state_changed: fn(&mut Self, WidgetState),
+    pub state: WidgetState,
 }
 
 impl<S, P> TextBox<S, P>
@@ -25,6 +29,11 @@ where
         self.on_state_changed = callback;
         self
     }
+}
+
+impl TextBox<(), ()> {
+    pub const STATE_SELECTED: Selected = Selected;
+    pub const STATE_UNSELECTED: Unselected = Unselected;
 }
 
 impl<S, P> Widget for TextBox<S, P>
@@ -59,12 +68,12 @@ where
         self.bounds.size = MeasuredSize { width, height };
     }
 
-    fn on_state_changed(&mut self, state: WidgetState) {
-        (self.on_state_changed)(self, state);
+    fn on_state_changed(&mut self, _state: WidgetState) {
+        // don't react to parent's state change
     }
 
     fn is_selectable(&self) -> bool {
-        false
+        true
     }
 }
 

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -1,8 +1,8 @@
 use crate::{
-    geometry::{measurement::MeasureSpec, BoundingBox, MeasuredSize},
+    geometry::{measurement::MeasureSpec, BoundingBox, MeasuredSize, Position},
     input::{
         controller::InputContext,
-        event::{InputEvent, KeyEvent, PointerEvent},
+        event::{InputEvent, Key, KeyEvent, Modifier, PointerEvent},
     },
     state::{
         selection::{Selected, Unselected},
@@ -15,6 +15,13 @@ use heapless::String;
 
 pub trait TextBoxProperties {
     fn measure_text(&self, text: &str, spec: MeasureSpec) -> MeasuredSize;
+    fn handle_keypress<const N: usize>(
+        &mut self,
+        key: Key,
+        modifier: Modifier,
+        text: &mut String<N>,
+    );
+    fn handle_cursor_down(&mut self, coordinates: Position);
 }
 
 pub struct TextBox<P, const N: usize> {
@@ -146,7 +153,7 @@ where
                 PointerEvent::Down => {
                     if self.bounding_box().contains(pos) {
                         self.change_state(TextBox::STATE_SELECTED);
-                        // TODO send to TextBox impl
+                        self.label_properties.handle_cursor_down(pos);
                     } else {
                         self.change_state(TextBox::STATE_UNSELECTED);
                     }
@@ -156,8 +163,8 @@ where
                 _ => false,
             },
             InputEvent::KeyEvent(KeyEvent::KeyDown(keycode, modifier, _repetition_counter)) => {
-                // TODO send to TextBox impl
-                println!("{:?}", keycode);
+                self.label_properties
+                    .handle_keypress(keycode, modifier, &mut self.text);
                 true
             }
             _ => {

--- a/src/widgets/toggle.rs
+++ b/src/widgets/toggle.rs
@@ -4,7 +4,7 @@ use crate::{
         controller::InputContext,
         event::{InputEvent, PointerEvent},
     },
-    state::{State, StateGroup, WidgetState},
+    state::{State, WidgetState},
     state_group,
     widgets::{utils::decorator::WidgetDecorator, Widget, WidgetDataHolder},
     Canvas, WidgetRenderer,

--- a/src/widgets/wrapper.rs
+++ b/src/widgets/wrapper.rs
@@ -12,6 +12,9 @@ where
     pub data_holder: WidgetDataHolder<W, D>,
 }
 
+/// Trait that lets you bind data to a widget.
+///
+/// Bound data allows manipulating the widget when the data changes.
 pub trait WrapperBindable: Widget + Sized {
     fn bind<D>(self, data: D) -> Wrapper<Self, D>
     where


### PR DESCRIPTION
This PR renames TextBox to TextBlock, and adds a new TextBox widget which is the editable version.

- [x] Create widget base
- [x] Make widget selectable
- [x] Port the embedded-text editor example's plugin
     Two parts: 
     * Cursor adjustment and display plugin
     * Editor helper struct
 - [x] Decide between two similar widgets or a single one with a more complex API (editable/read-only)
 - [x] Fix leading/trailing space behaviour. Editor needs to print every space. (https://github.com/embedded-graphics/embedded-text/issues/101)