### PR TITLE
Fix and re-enable alignment options

### DIFF
--- a/backend-embedded-graphics/Cargo.toml
+++ b/backend-embedded-graphics/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 
 [dependencies]
 embedded-graphics = "0.7.0"
-# embedded-text = { version = "0.5.0-beta.3", features = ["plugin"] }
-embedded-text = { git = "https://github.com/embedded-graphics/embedded-text", branch = "master", features = ["plugin"] }
+embedded-text = { version = "0.5.0-beta.4", features = ["plugin"] }
 embedded-gui = { path = ".." }
 heapless = "0.7"
 az = "1.1"

--- a/backend-embedded-graphics/src/widgets/text_box.rs
+++ b/backend-embedded-graphics/src/widgets/text_box.rs
@@ -27,7 +27,7 @@ use embedded_text::{
 
 pub use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
 use heapless::String;
-use object_chain::Chain;
+use object_chain::ChainElement;
 
 use crate::{widgets::text_box::plugin::Cursor, EgCanvas, ToPoint, ToRectangle};
 
@@ -355,7 +355,8 @@ where
 
             let result = textbox.draw(&mut canvas.target).map(|_| ());
 
-            let Chain { object: plugin } = textbox.take_plugins();
+            let plugins = textbox.take_plugins();
+            let (plugin, _plugins) = plugins.pop();
             self.fields.label_properties.cursor.set(plugin.get_cursor());
 
             result

--- a/backend-embedded-graphics/src/widgets/text_box.rs
+++ b/backend-embedded-graphics/src/widgets/text_box.rs
@@ -39,8 +39,8 @@ where
 {
     renderer: T,
     // Temporarily removed as alignments and editor together are a bit buggy
-    // horizontal: HorizontalAlignment,
-    // vertical: VerticalAlignment,
+    horizontal: HorizontalAlignment,
+    vertical: VerticalAlignment,
     cursor: Cell<Cursor>,
     cursor_color: Option<<T as TextRenderer>::Color>,
 }
@@ -79,8 +79,8 @@ where
             renderer: MonoTextStyleBuilder::from(&self.renderer)
                 .font(font)
                 .build(),
-            // horizontal: self.horizontal,
-            // vertical: self.vertical,
+            horizontal: self.horizontal,
+            vertical: self.vertical,
             cursor: Cell::new(Cursor::default()),
             cursor_color: None,
         }
@@ -170,9 +170,9 @@ where
     where
         P: TextBoxProperties;
 
-    // fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self;
+    fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self;
 
-    // fn vertical_alignment(self, alignment: VerticalAlignment) -> Self;
+    fn vertical_alignment(self, alignment: VerticalAlignment) -> Self;
 
     fn cursor_color(self, color: Self::Color) -> Self;
 }
@@ -197,14 +197,14 @@ where
         T2: TextRenderer + CharacterStyle<Color = <T2 as TextRenderer>::Color>,
         <T2 as TextRenderer>::Color: From<Rgb888>,
     {
-        // let horizontal = self.fields.label_properties.horizontal;
-        // let vertical = self.fields.label_properties.vertical;
+        let horizontal = self.fields.label_properties.horizontal;
+        let vertical = self.fields.label_properties.vertical;
         let cursor = self.fields.label_properties.cursor.clone();
 
         self.style(TextBoxStyle {
             renderer,
-            // horizontal,
-            // vertical,
+            horizontal,
+            vertical,
             cursor,
             cursor_color: None, // TODO: convert
         })
@@ -228,49 +228,49 @@ where
         }
     }
 
-    // fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self {
-    //     let renderer = self.fields.label_properties.renderer.clone();
-    //     let horizontal = alignment;
-    //     let vertical = self.fields.label_properties.vertical;
-    //     let cursor = self.fields.label_properties.cursor.clone();
-    //     let cursor_color = self.fields.label_properties.cursor_color;
-    //
-    //     self.style(TextBoxStyle {
-    //         renderer,
-    //         horizontal,
-    //         vertical,
-    //         cursor,
-    //         cursor_color,
-    //     })
-    // }
-    //
-    // fn vertical_alignment(self, alignment: VerticalAlignment) -> Self {
-    //     let renderer = self.fields.label_properties.renderer.clone();
-    //     let horizontal = self.fields.label_properties.horizontal;
-    //     let vertical = alignment;
-    //     let cursor = self.fields.label_properties.cursor.clone();
-    //     let cursor_color = self.fields.label_properties.cursor_color;
-    //
-    //     self.style(TextBoxStyle {
-    //         renderer,
-    //         horizontal,
-    //         vertical,
-    //         cursor,
-    //         cursor_color,
-    //     })
-    // }
+    fn horizontal_alignment(self, alignment: HorizontalAlignment) -> Self {
+        let renderer = self.fields.label_properties.renderer.clone();
+        let horizontal = alignment;
+        let vertical = self.fields.label_properties.vertical;
+        let cursor = self.fields.label_properties.cursor.clone();
+        let cursor_color = self.fields.label_properties.cursor_color;
+
+        self.style(TextBoxStyle {
+            renderer,
+            horizontal,
+            vertical,
+            cursor,
+            cursor_color,
+        })
+    }
+
+    fn vertical_alignment(self, alignment: VerticalAlignment) -> Self {
+        let renderer = self.fields.label_properties.renderer.clone();
+        let horizontal = self.fields.label_properties.horizontal;
+        let vertical = alignment;
+        let cursor = self.fields.label_properties.cursor.clone();
+        let cursor_color = self.fields.label_properties.cursor_color;
+
+        self.style(TextBoxStyle {
+            renderer,
+            horizontal,
+            vertical,
+            cursor,
+            cursor_color,
+        })
+    }
 
     fn cursor_color(self, color: C) -> Self {
         let renderer = self.fields.label_properties.renderer.clone();
-        // let horizontal = self.fields.label_properties.horizontal;
-        // let vertical = self.fields.label_properties.vertical;
+        let horizontal = self.fields.label_properties.horizontal;
+        let vertical = self.fields.label_properties.vertical;
         let cursor = self.fields.label_properties.cursor.clone();
         let cursor_color = Some(color);
 
         self.style(TextBoxStyle {
             renderer,
-            // horizontal,
-            // vertical,
+            horizontal,
+            vertical,
             cursor,
             cursor_color,
         })
@@ -304,15 +304,15 @@ where
         let renderer = MonoTextStyleBuilder::from(&self.fields.label_properties.renderer)
             .font(font)
             .build();
-        // let horizontal = self.fields.label_properties.horizontal;
-        // let vertical = self.fields.label_properties.vertical;
+        let horizontal = self.fields.label_properties.horizontal;
+        let vertical = self.fields.label_properties.vertical;
         let cursor = self.fields.label_properties.cursor.clone();
         let cursor_color = self.fields.label_properties.cursor_color;
 
         self.style(TextBoxStyle {
             renderer,
-            // horizontal,
-            // vertical,
+            horizontal,
+            vertical,
             cursor,
             cursor_color,
         })
@@ -339,8 +339,8 @@ where
                 .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
                 .leading_spaces(true)
                 .trailing_spaces(true)
-                // .alignment(self.fields.label_properties.horizontal)
-                // .vertical_alignment(self.fields.label_properties.vertical)
+                .alignment(self.fields.label_properties.horizontal)
+                .vertical_alignment(self.fields.label_properties.vertical)
                 .build(),
         );
 
@@ -382,8 +382,8 @@ macro_rules! textbox_for_charset {
                     utils::WidgetDataHolder,
                 },
             };
+            use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
             use heapless::String;
-            // use embedded_text::alignment::{HorizontalAlignment, VerticalAlignment};
 
             use crate::{
                 themes::Theme,
@@ -416,8 +416,8 @@ macro_rules! textbox_for_charset {
                                     &$charset::$font,
                                     <C as Theme>::TEXT_COLOR,
                                 ),
-                                // horizontal: HorizontalAlignment::Left,
-                                // vertical: VerticalAlignment::Top,
+                                horizontal: HorizontalAlignment::Left,
+                                vertical: VerticalAlignment::Top,
                                 cursor: Cell::new(Cursor::default()),
                                 cursor_color: Some(<C as Theme>::TEXT_COLOR),
                             },

--- a/backend-embedded-graphics/src/widgets/text_box/plugin.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/plugin.rs
@@ -154,10 +154,10 @@ impl Cursor {
     }
 
     pub fn delete_before<const N: usize>(&mut self, text: &mut String<N>) {
-        if self.offset > 0 {
-            self.offset -= 1;
-            self.desired_position = DesiredPosition::Offset(self.offset);
-            text.remove_char(self.offset);
+        if let Some(offset) = self.offset.checked_sub(1) {
+            self.offset = offset;
+            self.desired_position = DesiredPosition::Offset(offset);
+            text.remove_char(offset);
         }
     }
 
@@ -168,13 +168,11 @@ impl Cursor {
     }
 
     pub fn cursor_left(&mut self) {
-        if self.offset > 0 {
-            self.desired_position = DesiredPosition::Offset(self.offset - 1);
-        }
+        self.desired_position = DesiredPosition::Offset(self.offset.saturating_sub(1));
     }
 
     pub fn cursor_right(&mut self) {
-        self.desired_position = DesiredPosition::Offset(self.offset + 1);
+        self.desired_position = DesiredPosition::Offset(self.offset.saturating_add(1));
     }
 
     pub fn cursor_up(&mut self) {
@@ -191,8 +189,8 @@ impl Cursor {
         self.desired_position = DesiredPosition::ScreenCoordinates(point);
     }
 
-    pub fn plugin<C: PixelColor>(&self, color: C) -> EditorPlugin<C> {
-        EditorPlugin {
+    pub fn plugin<C: PixelColor>(&self, color: C) -> CursorPlugin<C> {
+        CursorPlugin {
             cursor_position: self.pos,
             current_offset: 0,
             desired_cursor_position: self.desired_position,
@@ -226,7 +224,7 @@ impl DesiredPosition {
 }
 
 #[derive(Clone)]
-pub(super) struct EditorPlugin<C> {
+pub(super) struct CursorPlugin<C> {
     desired_cursor_position: DesiredPosition,
     cursor_position: Point,
     current_offset: usize,
@@ -238,7 +236,7 @@ pub(super) struct EditorPlugin<C> {
     top_left: Point,
 }
 
-impl<C: PixelColor> EditorPlugin<C> {
+impl<C: PixelColor> CursorPlugin<C> {
     #[track_caller]
     fn draw_cursor<D>(
         &mut self,
@@ -249,7 +247,7 @@ impl<C: PixelColor> EditorPlugin<C> {
     where
         D: DrawTarget<Color = C>,
     {
-        let pos = Point::new(pos.x.max(self.top_left.x), pos.y);
+        let pos = Point::new((pos.x.saturating_sub(1)).max(self.top_left.x), pos.y);
         self.cursor_position = self.to_text_space(pos);
         self.cursor_drawn = true;
 
@@ -280,7 +278,7 @@ impl<C: PixelColor> EditorPlugin<C> {
     }
 }
 
-impl<'a, C: PixelColor> Plugin<'a, C> for EditorPlugin<C> {
+impl<'a, C: PixelColor> Plugin<'a, C> for CursorPlugin<C> {
     fn on_start_render<S: CharacterStyle + TextRenderer>(
         &mut self,
         cursor: &mut RenderingCursor,

--- a/backend-embedded-graphics/src/widgets/text_box/plugin.rs
+++ b/backend-embedded-graphics/src/widgets/text_box/plugin.rs
@@ -287,7 +287,7 @@ impl<'a, C: PixelColor> Plugin<'a, C> for EditorPlugin<C> {
         props: &TextBoxProperties<'_, S>,
     ) {
         let line_height = props.char_style.line_height() as i32;
-        self.top_left = props.bounding_box.top_left;
+        self.top_left = Point::new(props.bounding_box.top_left.x, cursor.y);
 
         self.desired_cursor_position = match self.desired_cursor_position {
             DesiredPosition::OneLineUp(old) => {

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -7,7 +7,7 @@ use backend_embedded_graphics::{
         text_block::{
             ascii::TextBlockConstructor, HorizontalAlignment, TextBlockStyling, VerticalAlignment,
         },
-        text_box::ascii::TextBoxConstructor,
+        text_box::{ascii::TextBoxConstructor, TextBoxStyling},
     },
     EgCanvas,
 };
@@ -269,6 +269,8 @@ fn main() {
                     TextBox::new(String::<100>::from(
                         "A TextBox with editable content. Click me and start typing!",
                     ))
+                    .horizontal_alignment(HorizontalAlignment::Center)
+                    .vertical_alignment(VerticalAlignment::Middle)
                     .bind(&text_reset)
                     .on_data_changed(|text_box, reset| {
                         if *reset {

--- a/examples/kitchen_sink_rgb.rs
+++ b/examples/kitchen_sink_rgb.rs
@@ -7,7 +7,7 @@ use backend_embedded_graphics::{
         text_block::{
             ascii::TextBlockConstructor, HorizontalAlignment, TextBlockStyling, VerticalAlignment,
         },
-        text_box::ascii::TextBoxConstructor,
+        text_box::{ascii::TextBoxConstructor, TextBoxStyling},
     },
     EgCanvas,
 };
@@ -274,6 +274,8 @@ fn main() {
                     TextBox::new(
                         String::<100>::from("A TextBox with editable content. Click me and start typing!")
                     )
+                    .horizontal_alignment(HorizontalAlignment::Center)
+                    .vertical_alignment(VerticalAlignment::Middle)
                     .bind(&text_reset)
                     .on_data_changed(|text_box, (reset, _empty)| {
                         if *reset {


### PR DESCRIPTION
Some quirks have been fixed in embedded-text, which may have fixed all horizontal alignment bugs. Vertical alignment issues are probably specific to the editor plugin.

 - [x] Fix horizontal alignment issues
 - [x] Fix vertical alignment issues

Closes #52