### PR TITLE
Add a simple canvas widget

### DIFF
--- a/backend-embedded-graphics/Cargo.toml
+++ b/backend-embedded-graphics/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dániel Buga <bugadani@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+embedded-canvas = "0.2.0"
 embedded-graphics = "0.7.0"
 embedded-text = { version = "0.5.0", features = ["plugin"] }
 embedded-gui = { path = ".." }
@@ -14,4 +15,5 @@ object-chain = "0.1"
 
 [features]
 ansi = ["embedded-text/ansi"]
+std = ["embedded-canvas/alloc"]
 default = ["ansi"]

--- a/backend-embedded-graphics/src/lib.rs
+++ b/backend-embedded-graphics/src/lib.rs
@@ -49,6 +49,8 @@ use embedded_gui::{
     Canvas,
 };
 
+pub use embedded_canvas;
+
 trait ToPoint {
     fn to_point(self) -> Point;
 }

--- a/backend-embedded-graphics/src/widgets/canvas.rs
+++ b/backend-embedded-graphics/src/widgets/canvas.rs
@@ -252,7 +252,10 @@ where
                 }
             }
 
-            InputEvent::PointerEvent(position, PointerEvent::Drag | PointerEvent::Hover) => {
+            // We want controls drawn above the Canvas to get input events.
+            InputEvent::PointerEvent(_, PointerEvent::Hover) => None,
+
+            InputEvent::PointerEvent(position, PointerEvent::Drag) => {
                 if bounds.contains(position) {
                     Some(0)
                 } else {

--- a/backend-embedded-graphics/src/widgets/canvas.rs
+++ b/backend-embedded-graphics/src/widgets/canvas.rs
@@ -23,9 +23,10 @@ use crate::{themes::Theme, EgCanvas, ToRectangle};
 
 pub trait CanvasProperties {
     type Color;
-    type Canvas: DrawTargetExt + Drawable<Color = Self::Color>;
+    type Canvas: DrawTarget<Color = Self::Color> + DrawTargetExt + Drawable<Color = Self::Color>;
 
     fn canvas(&mut self) -> &mut Self::Canvas;
+    fn clear_color(&mut self) -> Self::Color;
     fn measure(&self) -> MeasuredSize;
 }
 
@@ -46,6 +47,10 @@ where
 
     fn canvas(&mut self) -> &mut Self::Canvas {
         &mut self.canvas
+    }
+
+    fn clear_color(&mut self) -> Self::Color {
+        self.clear_color
     }
 
     fn measure(&self) -> MeasuredSize {
@@ -103,6 +108,10 @@ where
 
     fn canvas(&mut self) -> &mut Self::Canvas {
         &mut self.canvas
+    }
+
+    fn clear_color(&mut self) -> Self::Color {
+        self.clear_color
     }
 
     fn measure(&self) -> MeasuredSize {

--- a/backend-embedded-graphics/src/widgets/canvas.rs
+++ b/backend-embedded-graphics/src/widgets/canvas.rs
@@ -1,5 +1,6 @@
 use embedded_canvas::CCanvasAt;
 use embedded_graphics::{
+    draw_target::Cropped,
     prelude::{Dimensions, DrawTarget, DrawTargetExt, PixelColor, Point, Size},
     Drawable,
 };
@@ -170,13 +171,7 @@ impl<P, H> Canvas<P, H>
 where
     H: FnMut(InputContext, InputEvent) -> bool,
 {
-    pub fn canvas(
-        &mut self,
-    ) -> impl DrawTarget<
-        Color = <P::Canvas as DrawTarget>::Color,
-        Error = <P::Canvas as DrawTarget>::Error,
-    > + Dimensions
-           + '_
+    pub fn canvas(&mut self) -> Cropped<'_, P::Canvas>
     where
         P: CanvasProperties,
     {

--- a/backend-embedded-graphics/src/widgets/canvas.rs
+++ b/backend-embedded-graphics/src/widgets/canvas.rs
@@ -1,0 +1,214 @@
+use embedded_canvas::{ CCanvasAt};
+use embedded_graphics::{
+    prelude::{DrawTarget, PixelColor, Point, Dimensions, Size},
+    Drawable,
+};
+use embedded_gui::{
+    geometry::{measurement::MeasureSpec, BoundingBox, MeasuredSize, Position},
+    prelude::WrapperBindable,
+    state::WidgetState,
+    widgets::Widget,
+    WidgetRenderer,
+};
+
+use crate::{themes::Theme, EgCanvas};
+
+pub trait CanvasProperties {
+    type Color;
+    type Canvas: Drawable<Color = Self::Color>;
+
+    fn canvas(&mut self) -> &mut Self::Canvas;
+    fn measure(&self) -> MeasuredSize;
+    fn move_canvas(&mut self, pos: Position);
+}
+
+pub struct CCanvasStyle<C, const W: usize, const H: usize>
+where
+    C: PixelColor,
+{
+    pub clear_color: C,
+    pub canvas: CCanvasAt<C, W, H>,
+}
+
+impl<C, const W: usize, const H: usize> CanvasProperties for CCanvasStyle<C, W, H>
+where
+    C: PixelColor,
+{
+    type Color = C;
+    type Canvas = CCanvasAt<C, W, H>;
+
+    fn canvas(&mut self) -> &mut Self::Canvas {
+        &mut self.canvas
+    }
+
+    fn measure(&self) -> MeasuredSize {
+        MeasuredSize {
+            width: W as u32,
+            height: H as u32,
+        }
+    }
+
+    fn move_canvas(&mut self, pos: Position) {
+        self.canvas.top_left = Point { x: pos.x, y: pos.y };
+    }
+}
+
+impl<C, const W: usize, const H: usize> Default for CCanvasStyle<C, W, H>
+where
+    C: Theme,
+{
+    fn default() -> Self {
+        Self {
+            clear_color: C::BACKGROUND_COLOR,
+            canvas: CCanvasAt::new(Point::zero()),
+        }
+    }
+}
+
+//#[cfg(feature = "std")]
+use embedded_canvas::CanvasAt;
+
+//#[cfg(feature = "std")]
+pub struct CanvasStyle<C>
+where
+C: PixelColor,
+{
+    pub clear_color: C,
+    pub canvas: CanvasAt<C>,
+}
+
+
+//#[cfg(feature = "std")]
+impl<C> CanvasStyle<C>
+where
+    C: Theme,
+{
+    pub fn new(size: Size) -> Self {
+        Self {
+            clear_color: C::BACKGROUND_COLOR,
+            canvas: CanvasAt::new(Point::zero(), size),
+        }
+    }
+}
+
+//#[cfg(feature = "std")]
+impl<C> CanvasProperties for CanvasStyle<C>
+where
+    C: PixelColor,
+{
+    type Color = C;
+    type Canvas = CanvasAt<C>;
+
+    fn canvas(&mut self) -> &mut Self::Canvas {
+        &mut self.canvas
+    }
+
+    fn measure(&self) -> MeasuredSize {
+        MeasuredSize {
+            width: self.canvas.bounding_box().size.width,
+            height: self.canvas.bounding_box().size.height,
+        }
+    }
+
+    fn move_canvas(&mut self, pos: Position) {
+        self.canvas.top_left = Point { x: pos.x, y: pos.y };
+    }
+}
+
+//#[cfg(feature = "std")]
+impl<C> Default for CanvasStyle<C>
+where
+    C: Theme,
+{
+    fn default() -> Self {
+        Self {
+            clear_color: C::BACKGROUND_COLOR,
+            canvas: CanvasAt::new(Point::zero(), Size::zero()),
+        }
+    }
+}
+
+pub struct Canvas<P> {
+    pub bounds: BoundingBox,
+    pub parent_index: usize,
+    pub canvas_properties: P,
+}
+
+impl<P> Canvas<P> {
+    pub fn new() -> Self
+    where
+        P: Default,
+    {
+        Self {
+            parent_index: 0,
+            bounds: BoundingBox::default(),
+            canvas_properties: P::default(),
+        }
+    }
+
+    pub fn with_properties(properties: P) -> Self
+    where
+        P: Default,
+    {
+        Self {
+            parent_index: 0,
+            bounds: BoundingBox::default(),
+            canvas_properties: properties,
+        }
+    }
+
+    pub fn canvas(&mut self) -> &mut P::Canvas
+    where
+        P: CanvasProperties,
+    {
+        self.canvas_properties.canvas()
+    }
+}
+
+impl<P> WrapperBindable for Canvas<P> where P: CanvasProperties {}
+
+impl<P> Widget for Canvas<P>
+where
+    P: CanvasProperties,
+{
+    fn bounding_box(&self) -> BoundingBox {
+        self.bounds
+    }
+
+    fn bounding_box_mut(&mut self) -> &mut BoundingBox {
+        &mut self.bounds
+    }
+
+    fn measure(&mut self, measure_spec: MeasureSpec) {
+        let canvas_size = self.canvas_properties.measure();
+
+        let width = measure_spec.width.apply_to_measured(canvas_size.width);
+        let height = measure_spec.height.apply_to_measured(canvas_size.height);
+
+        self.bounds.size = MeasuredSize { width, height };
+    }
+
+    fn parent_index(&self) -> usize {
+        self.parent_index
+    }
+
+    fn set_parent(&mut self, index: usize) {
+        self.parent_index = index;
+    }
+
+    fn on_state_changed(&mut self, _: WidgetState) {}
+}
+
+impl<C, DT, P> WidgetRenderer<EgCanvas<DT>> for Canvas<P>
+where
+    C: PixelColor,
+    DT: DrawTarget<Color = C>,
+    P: CanvasProperties<Color = C>,
+{
+    fn draw(&mut self, canvas: &mut EgCanvas<DT>) -> Result<(), DT::Error> {
+        self.canvas_properties.move_canvas(self.bounds.position);
+        self.canvas().draw(&mut canvas.target)?;
+
+        Ok(())
+    }
+}

--- a/backend-embedded-graphics/src/widgets/mod.rs
+++ b/backend-embedded-graphics/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod background;
 pub mod border;
+pub mod canvas;
 pub mod graphical;
 pub mod label;
 pub mod scroll;

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -2,7 +2,7 @@ use std::{thread, time::Duration};
 
 use backend_embedded_graphics::{
     themes::{default::DefaultTheme, Theme},
-    widgets::canvas::{Canvas, CanvasProperties, CanvasStyle},
+    widgets::canvas::{Canvas, CanvasStyle},
     EgCanvas,
 };
 use embedded_graphics::{
@@ -201,14 +201,8 @@ fn main() {
                         });
                         true
                     })
-                    .bind(&state)
-                    .on_data_changed(|widget, state| {
-                        let clear_color = widget.canvas_properties.clear_color();
-                        let mut canvas = widget.canvas();
-
-                        canvas.clear(clear_color).unwrap();
-
-                        let t = state.time % 100;
+                    .with_on_draw(|canvas| {
+                        let t = state.with_data(|state| state.time % 100);
 
                         let increment = if t < 50 { t } else { 50 - (t - 50) };
 
@@ -220,13 +214,15 @@ fn main() {
                             },
                         )
                         .into_styled(PrimitiveStyle::with_stroke(Rgb888::BLUE, 1));
-                        rectangle.draw(&mut canvas).unwrap();
+                        rectangle.draw(canvas).unwrap();
 
                         let circle =
                             Circle::with_center(canvas.bounding_box().center(), 40 + increment)
                                 .into_styled(PrimitiveStyle::with_stroke(Rgb888::RED, 1));
-                        circle.draw(&mut canvas).unwrap();
-                    }),
+                        circle.draw(canvas).unwrap();
+                    })
+                    .bind(&state)
+                    .on_data_changed(|widget, _| widget.invalidate()),
             )))
             .add_layer(
                 DefaultTheme::primary_button("Animate")

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -1,0 +1,162 @@
+use std::{thread, time::Duration};
+
+use backend_embedded_graphics::{
+    themes::{default::DefaultTheme, Theme},
+    widgets::canvas::{Canvas, CanvasStyle},
+    EgCanvas,
+};
+use embedded_graphics::{
+    draw_target::DrawTarget,
+    pixelcolor::Rgb888,
+    prelude::{RgbColor, Size as EgSize},
+    primitives::{Circle, Primitive, PrimitiveStyle, Rectangle},
+    Drawable,
+};
+use embedded_graphics_simulator::{
+    sdl2::MouseButton, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window as SimWindow,
+};
+use embedded_gui::{
+    data::BoundData,
+    geometry::Position,
+    input::event::{InputEvent, PointerEvent},
+    prelude::*,
+    widgets::{border::Border, fill::FillParent, layouts::linear::Column},
+};
+
+fn convert_input(event: SimulatorEvent) -> Result<InputEvent, bool> {
+    unsafe {
+        // This is fine for a demo
+        static mut MOUSE_DOWN: bool = false;
+        match event {
+            SimulatorEvent::MouseButtonUp {
+                mouse_btn: MouseButton::Left,
+                point,
+            } => {
+                MOUSE_DOWN = false;
+                Ok(InputEvent::PointerEvent(
+                    Position {
+                        x: point.x,
+                        y: point.y,
+                    },
+                    PointerEvent::Up,
+                ))
+            }
+            SimulatorEvent::MouseButtonDown {
+                mouse_btn: MouseButton::Left,
+                point,
+            } => {
+                MOUSE_DOWN = true;
+                Ok(InputEvent::PointerEvent(
+                    Position {
+                        x: point.x,
+                        y: point.y,
+                    },
+                    PointerEvent::Down,
+                ))
+            }
+            SimulatorEvent::MouseMove { point } => Ok(InputEvent::PointerEvent(
+                Position {
+                    x: point.x,
+                    y: point.y,
+                },
+                if MOUSE_DOWN {
+                    PointerEvent::Drag
+                } else {
+                    PointerEvent::Hover
+                },
+            )),
+            SimulatorEvent::Quit => Err(true),
+            _ => Err(false),
+        }
+    }
+}
+
+struct AnimationState {
+    enabled: bool,
+    time: u32,
+}
+
+fn main() {
+    let display = SimulatorDisplay::new(EgSize::new(256, 128));
+
+    let state = BoundData::new(
+        AnimationState {
+            enabled: false,
+            time: 0,
+        },
+        |_| {},
+    );
+
+    let mut gui = Window::new(
+        EgCanvas::new(display),
+        Column::new()
+            .add(
+                DefaultTheme::primary_button("Animate")
+                    .bind(&state)
+                    .on_clicked(|state| state.enabled = !state.enabled),
+            )
+            .add(FillParent::both(Border::new(
+                Canvas::with_properties(CanvasStyle::<Rgb888>::new(EgSize::new(256, 128)))
+                    .bind(&state)
+                    .on_data_changed(|widget, state| {
+                        let clear_color = widget.canvas_properties.clear_color;
+                        let canvas = widget.canvas();
+
+                        canvas.clear(clear_color).unwrap();
+
+                        let t = state.time % 100;
+
+                        let increment = if t < 50 { t } else { 50 - (t - 50) };
+
+                        let rectangle = Rectangle::with_center(
+                            canvas.center(),
+                            EgSize {
+                                width: 50 + increment,
+                                height: 50 + increment,
+                            },
+                        )
+                        .into_styled(PrimitiveStyle::with_stroke(Rgb888::BLUE, 1));
+                        rectangle.draw(canvas).unwrap();
+
+                        let circle = Circle::with_center(canvas.center(), 40 + increment)
+                            .into_styled(PrimitiveStyle::with_stroke(Rgb888::RED, 1));
+                        circle.draw(canvas).unwrap();
+                    }),
+            ))),
+    );
+
+    let output_settings = OutputSettingsBuilder::new().scale(2).build();
+    let mut window = SimWindow::new("GUI demonstration", &output_settings);
+
+    loop {
+        gui.canvas.target.clear(Rgb888::BACKGROUND_COLOR).unwrap();
+
+        gui.update();
+        gui.measure();
+        gui.arrange();
+        gui.draw().unwrap();
+
+        state.update(|state| {
+            if state.enabled {
+                state.time = state.time.wrapping_add(1);
+            }
+        });
+
+        // Update the window.
+        window.update(&gui.canvas.target);
+
+        // Handle key and mouse events.
+        for event in window.events() {
+            match convert_input(event) {
+                Ok(input) => {
+                    gui.input_event(input);
+                }
+                Err(true) => return,
+                _ => {}
+            }
+        }
+
+        // Wait for a little while.
+        thread::sleep(Duration::from_millis(10));
+    }
+}

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -8,7 +8,7 @@ use backend_embedded_graphics::{
 use embedded_graphics::{
     draw_target::DrawTarget,
     pixelcolor::Rgb888,
-    prelude::{RgbColor, Size as EgSize},
+    prelude::{Dimensions, RgbColor, Size as EgSize},
     primitives::{Circle, Primitive, PrimitiveStyle, Rectangle},
     Drawable,
 };
@@ -209,7 +209,7 @@ fn main() {
                     .bind(&state)
                     .on_data_changed(|widget, state| {
                         let clear_color = widget.canvas_properties.clear_color;
-                        let canvas = widget.canvas();
+                        let mut canvas = widget.canvas();
 
                         canvas.clear(clear_color).unwrap();
 
@@ -218,18 +218,19 @@ fn main() {
                         let increment = if t < 50 { t } else { 50 - (t - 50) };
 
                         let rectangle = Rectangle::with_center(
-                            canvas.center(),
+                            canvas.bounding_box().center(),
                             EgSize {
                                 width: 50 + increment,
                                 height: 50 + increment,
                             },
                         )
                         .into_styled(PrimitiveStyle::with_stroke(Rgb888::BLUE, 1));
-                        rectangle.draw(canvas).unwrap();
+                        rectangle.draw(&mut canvas).unwrap();
 
-                        let circle = Circle::with_center(canvas.center(), 40 + increment)
-                            .into_styled(PrimitiveStyle::with_stroke(Rgb888::RED, 1));
-                        circle.draw(canvas).unwrap();
+                        let circle =
+                            Circle::with_center(canvas.bounding_box().center(), 40 + increment)
+                                .into_styled(PrimitiveStyle::with_stroke(Rgb888::RED, 1));
+                        circle.draw(&mut canvas).unwrap();
                     }),
             ))),
     );

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -2,7 +2,7 @@ use std::{thread, time::Duration};
 
 use backend_embedded_graphics::{
     themes::{default::DefaultTheme, Theme},
-    widgets::canvas::{Canvas, CanvasStyle},
+    widgets::canvas::{Canvas, CanvasProperties, CanvasStyle},
     EgCanvas,
 };
 use embedded_graphics::{
@@ -203,7 +203,7 @@ fn main() {
                     })
                     .bind(&state)
                     .on_data_changed(|widget, state| {
-                        let clear_color = widget.canvas_properties.clear_color;
+                        let clear_color = widget.canvas_properties.clear_color();
                         let mut canvas = widget.canvas();
 
                         canvas.clear(clear_color).unwrap();

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -21,7 +21,7 @@ use embedded_gui::{
     geometry::Position,
     input::event::{InputEvent, Key, KeyEvent, Modifier, PointerEvent},
     prelude::*,
-    widgets::{border::Border, fill::FillParent, layouts::linear::Column},
+    widgets::{border::Border, fill::FillParent, layouts::frame::Frame},
 };
 
 trait Convert {
@@ -184,13 +184,8 @@ fn main() {
 
     let mut gui = Window::new(
         EgCanvas::new(display),
-        Column::new()
-            .add(
-                DefaultTheme::primary_button("Animate")
-                    .bind(&state)
-                    .on_clicked(|state| state.enabled = !state.enabled),
-            )
-            .add(FillParent::both(Border::new(
+        Frame::new()
+            .add_layer(FillParent::both(Border::new(
                 Canvas::with_properties(CanvasStyle::<Rgb888>::new(EgSize::new(256, 128)))
                     .with_input_handler(|_ctxt, input| {
                         state.update(|data| match input {
@@ -232,7 +227,12 @@ fn main() {
                                 .into_styled(PrimitiveStyle::with_stroke(Rgb888::RED, 1));
                         circle.draw(&mut canvas).unwrap();
                     }),
-            ))),
+            )))
+            .add_layer(
+                DefaultTheme::primary_button("Animate")
+                    .bind(&state)
+                    .on_clicked(|state| state.enabled = !state.enabled),
+            ),
     );
 
     let output_settings = OutputSettingsBuilder::new().scale(2).build();


### PR DESCRIPTION
This PR implements a very basic widget to draw on.

TODO:
 - [ ] Transform mouse event coordinates
 - [ ] Turn the canvas into a data holder so that we can work with the bound data directly instead of going through an external reference